### PR TITLE
Add final tester walkthrough scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,85 @@
-# REPHUB
+# REPHUB – Kalkulator dawek paszowych
+
+Nowoczesna aplikacja KivyMD dla hodowców bydła mlecznego i opasowego. Projekt został
+zrealizowany modułowo zgodnie z siedmiostopniowym planem: zarządzanie bazą pasz,
+obliczenia wartości pokarmowych, panel hodowcy, interfejs graficzny, zapisywanie i
+porównywanie dawek, walidacja oraz tryb testera końcowego.
+
+## Przegląd modułów
+
+1. **Zarządzanie paszami** – referencyjna baza pasz, dodawanie i edycja danych, zarządzanie
+   dawką bieżącą.
+2. **Obliczenia żywieniowe** – analizy suchej masy, białka, energii i włókna z obsługą braków
+   danych.
+3. **Panel hodowcy** – projekcje logistyczne dla stada, liczba załadunków i wystarczalność
+   zapasów.
+4. **Interfejs KivyMD** – aplikacja desktopowa z zakładkami dla dawki, panelu hodowcy i
+   zapisanych dawek.
+5. **Zapisywanie i porównania** – trwałe przechowywanie dawek w JSON oraz karty porównawcze.
+6. **Walidacja danych** – wychwytywanie błędnych wartości i bezpieczne zastępowanie ich w
+   obliczeniach.
+7. **Tryb testera końcowego** – automatyczny scenariusz przechodzący przez wszystkie funkcje,
+   ułatwiający testy końcowe.
+
+## Wymagania
+
+* Python 3.10+
+* Pip oraz opcjonalnie wirtualne środowisko (`venv`)
+
+## Instalacja i uruchomienie
+
+1. **Sklonuj repozytorium oraz przejdź do katalogu projektu.**
+   ```bash
+   git clone <adres_repozytorium>
+   cd REPHUB
+   ```
+2. **(Opcjonalnie) utwórz i aktywuj wirtualne środowisko.**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
+   ```
+3. **Zainstaluj zależności.**
+   ```bash
+   pip install -r requirements.txt
+   ```
+   Jeżeli plik `requirements.txt` jest niedostępny, zainstaluj ręcznie `kivy`, `kivymd` oraz
+   `pytest`.
+4. **Uruchom aplikację.**
+   ```bash
+   python main.py
+   ```
+   Pierwsze uruchomienie załaduje przykładową dawkę oraz umożliwi zarządzanie paszami,
+   obliczeniami i zapisami.
+
+## Testy i scenariusz końcowy
+
+* Uruchom zestaw testów jednostkowych:
+  ```bash
+  pytest
+  ```
+* Uruchom automatyczny tryb testera końcowego bez uruchamiania GUI:
+  ```bash
+  python - <<'PY'
+  from pathlib import Path
+  from app.testing import FinalTester
+
+  report = FinalTester(Path('tester_saved.json')).run_walkthrough()
+  print('Przygotowano raport testowy z', len(report.saved_state.rows), 'dawkami.')
+  PY
+  ```
+  Wynik pozwala szybko zweryfikować przepływ zapis/edycja/porównanie wraz z ostrzeżeniami.
+
+## Pakietowanie na Windows (opcjonalnie)
+
+Projekt można spakować do pliku `.exe` przy pomocy narzędzia `PyInstaller`:
+```bash
+pip install pyinstaller
+pyinstaller --name RationPlanner --onefile main.py
+```
+
+## Znane ograniczenia
+
+* Interfejs użytkownika udostępnia jeden język (PL), ale struktura została przygotowana na
+  przyszłą rozbudowę o kolejne tłumaczenia.
+* Dane paszowe są przykładowe – w realnym wdrożeniu zaleca się import własnych analiz
+  laboratoryjnych.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package for the cattle feeding calculator."""

--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -1,0 +1,1 @@
+"""Data access utilities and default datasets."""

--- a/app/data/default_feeds.py
+++ b/app/data/default_feeds.py
@@ -1,0 +1,74 @@
+"""Default feed dataset used to bootstrap the application."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict, List
+
+from app.models.feed import FeedDefinition, FeedType, NutritionalProfile
+
+
+def build_default_feeds() -> List[FeedDefinition]:
+    """Return the list of predefined feed definitions shipped with the app."""
+
+    today = date.today()
+    defaults: Dict[str, Dict[str, float]] = {
+        "Kiszonka z kukurydzy": {
+            "protein_percent": 8.0,
+            "energy_mj_per_kg_dm": 6.5,
+            "dry_matter_percent": 32.0,
+            "fiber_percent": 19.0,
+            "feed_type": FeedType.ROUGHAGE,
+        },
+        "Kiszonka z traw": {
+            "protein_percent": 14.0,
+            "energy_mj_per_kg_dm": 5.8,
+            "dry_matter_percent": 38.0,
+            "fiber_percent": 25.0,
+            "feed_type": FeedType.ROUGHAGE,
+        },
+        "Siano łąkowe": {
+            "protein_percent": 10.0,
+            "energy_mj_per_kg_dm": 5.4,
+            "dry_matter_percent": 85.0,
+            "fiber_percent": 28.0,
+            "feed_type": FeedType.ROUGHAGE,
+        },
+        "Śruta sojowa": {
+            "protein_percent": 45.0,
+            "energy_mj_per_kg_dm": 7.5,
+            "dry_matter_percent": 88.0,
+            "fiber_percent": 6.0,
+            "feed_type": FeedType.CONCENTRATE,
+        },
+        "Ziarno kukurydzy": {
+            "protein_percent": 9.0,
+            "energy_mj_per_kg_dm": 7.2,
+            "dry_matter_percent": 86.0,
+            "fiber_percent": 2.0,
+            "feed_type": FeedType.CONCENTRATE,
+        },
+        "Wysłodki buraczane (susz)": {
+            "protein_percent": 9.0,
+            "energy_mj_per_kg_dm": 6.9,
+            "dry_matter_percent": 90.0,
+            "fiber_percent": 16.0,
+            "feed_type": FeedType.CONCENTRATE,
+        },
+    }
+
+    feeds: List[FeedDefinition] = []
+    for name, payload in defaults.items():
+        feed_type = payload.pop("feed_type")
+        profile = NutritionalProfile(**payload)
+        feeds.append(
+            FeedDefinition(
+                name=name,
+                feed_type=feed_type,
+                profile=profile,
+                source="Średnie wartości referencyjne",
+                added_on=today,
+                is_default=True,
+            )
+        )
+    return feeds

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,29 @@
+"""Domain models describing feeds, nutrition and herd-level projections."""
+
+from .feed import FeedDefinition, FeedType, NutritionalProfile, RationFeedItem
+from .herd import HerdLogisticsSummary, HerdProjection, ProductionType
+from .nutrition import FeedContribution, NutrientMeasurement, RationAnalysis, RationTotals
+from .saved_ration import (
+    FeedShareComparison,
+    NutrientComparison,
+    RationComparison,
+    SavedRation,
+)
+
+__all__ = [
+    "FeedDefinition",
+    "FeedType",
+    "NutritionalProfile",
+    "RationFeedItem",
+    "HerdLogisticsSummary",
+    "HerdProjection",
+    "ProductionType",
+    "FeedContribution",
+    "NutrientMeasurement",
+    "RationAnalysis",
+    "RationTotals",
+    "SavedRation",
+    "RationComparison",
+    "NutrientComparison",
+    "FeedShareComparison",
+]

--- a/app/models/feed.py
+++ b/app/models/feed.py
@@ -1,0 +1,143 @@
+"""Feed data models.
+
+This module defines data structures representing feed definitions and nutritional values
+used throughout the feeding calculator application. Each class contains convenience
+methods to support validation and transformation logic for Module 1 (Feed data
+management).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import date
+from enum import Enum
+from typing import Dict, Iterable, Optional
+
+
+class FeedType(str, Enum):
+    """Enumerates supported feed categories."""
+
+    ROUGHAGE = "roughage"
+    CONCENTRATE = "concentrate"
+
+    @classmethod
+    def from_label(cls, label: str) -> "FeedType":
+        """Return the enum value matching a user-facing label.
+
+        The method is forgiving with regards to casing and whitespace. It raises
+        ``ValueError`` when the label cannot be mapped to any known feed type.
+        """
+
+        normalized = label.strip().lower()
+        mapping = {
+            "objętościowa": cls.ROUGHAGE,
+            "objetosciowa": cls.ROUGHAGE,
+            "roughage": cls.ROUGHAGE,
+            "treściwa": cls.CONCENTRATE,
+            "tresciwa": cls.CONCENTRATE,
+            "concentrate": cls.CONCENTRATE,
+        }
+        try:
+            return mapping[normalized]
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise ValueError(f"Unknown feed type label: {label}") from exc
+
+
+@dataclass(frozen=True)
+class NutritionalProfile:
+    """Stores nutritional attributes for a feed item.
+
+    All values are optional to support incomplete datasets. Percentages are expressed
+    on fresh matter basis except for energy, which is already expressed per kilogram of
+    dry matter (MJ/kg SM).
+    """
+
+    protein_percent: Optional[float] = None
+    energy_mj_per_kg_dm: Optional[float] = None
+    dry_matter_percent: Optional[float] = None
+    fiber_percent: Optional[float] = None
+
+    def merged_with(self, other: "NutritionalProfile") -> "NutritionalProfile":
+        """Combine two profiles, preferring explicitly provided values.
+
+        ``None`` values in ``self`` are replaced by ``other`` where available. The
+        returned instance is a new dataclass copy, keeping the original objects intact.
+        """
+
+        data: Dict[str, Optional[float]] = self.__dict__.copy()
+        for field, value in other.__dict__.items():
+            if data[field] is None and value is not None:
+                data[field] = value
+        return NutritionalProfile(**data)
+
+    def to_dict(self) -> Dict[str, Optional[float]]:
+        """Represent the profile as a plain dictionary suitable for serialization."""
+
+        return dict(self.__dict__)
+
+
+@dataclass(frozen=True)
+class FeedDefinition:
+    """Represents a catalog feed entry (default or user defined)."""
+
+    name: str
+    feed_type: FeedType
+    profile: NutritionalProfile
+    source: Optional[str] = None
+    added_on: Optional[date] = None
+    is_default: bool = False
+
+    def with_profile(self, profile: NutritionalProfile) -> "FeedDefinition":
+        """Return a copy of this definition with a different profile."""
+
+        return replace(self, profile=profile)
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        """Serialize the feed definition to a dictionary for UI consumption."""
+
+        data = {
+            "name": self.name,
+            "feed_type": self.feed_type.value,
+            "source": self.source,
+            "added_on": self.added_on.isoformat() if self.added_on else None,
+            "is_default": self.is_default,
+        }
+        data.update(self.profile.to_dict())
+        return data
+
+
+@dataclass
+class RationFeedItem:
+    """Represents a feed entry in the current ration being composed by the user."""
+
+    name: str
+    quantity_kg: float
+    use_default_profile: bool
+    manual_profile: NutritionalProfile
+
+    def resolve_profile(self, catalog: Iterable[FeedDefinition]) -> NutritionalProfile:
+        """Return the nutritional profile that should be used for calculations.
+
+        If ``use_default_profile`` is true, attempt to fetch the default profile from
+        the provided catalog definitions. When manual values are provided, they override
+        defaults as long as they are not ``None``.
+        """
+
+        if not self.use_default_profile:
+            return self.manual_profile
+
+        for definition in catalog:
+            if definition.name == self.name:
+                return self.manual_profile.merged_with(definition.profile)
+        return self.manual_profile
+
+    def to_dict(self) -> Dict[str, Optional[str]]:
+        """Serialize the ration item for UI components."""
+
+        data = {
+            "name": self.name,
+            "quantity_kg": self.quantity_kg,
+            "use_default_profile": self.use_default_profile,
+        }
+        data.update(self.manual_profile.to_dict())
+        return data

--- a/app/models/herd.py
+++ b/app/models/herd.py
@@ -1,0 +1,72 @@
+"""Herd-level planning data models for Module 3.
+
+This module defines domain structures that represent the results of the herd
+planning computations. They encapsulate the derived daily and monthly feed
+requirements for the whole herd together with metadata required by the user
+interface layer. The models complement the nutritional outputs calculated in
+Module 2 and provide a foundation for the farmer panel logic implemented later
+in the KivyMD application.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional
+
+from app.models.nutrition import RationAnalysis, RationTotals
+
+
+class ProductionType(str, Enum):
+    """Enumerates supported production profiles for the herd."""
+
+    MILK = "milk"
+    BEEF = "beef"
+
+    @classmethod
+    def from_label(cls, label: str) -> "ProductionType":
+        """Return the enum value matching a human readable label.
+
+        The helper is tolerant towards casing and Polish diacritics so that UI
+        inputs can be mapped safely regardless of the text entered by the user.
+        An informative ``ValueError`` is raised when the label is unknown.
+        """
+
+        normalized = label.strip().lower()
+        mapping = {
+            "mleczne": cls.MILK,
+            "produkcja mleczna": cls.MILK,
+            "milk": cls.MILK,
+            "opasowe": cls.BEEF,
+            "produkcja opasowa": cls.BEEF,
+            "beef": cls.BEEF,
+        }
+        try:
+            return mapping[normalized]
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise ValueError(f"Unknown production type label: {label}") from exc
+
+
+@dataclass(frozen=True)
+class HerdLogisticsSummary:
+    """Stores calculated feed logistics for the entire herd."""
+
+    per_animal_fresh_mass_kg: Optional[float]
+    daily_fresh_mass_kg: Optional[float]
+    monthly_fresh_mass_kg: Optional[float]
+    mixer_loads_per_day: Optional[int]
+    wagon_loads_per_day: Optional[int]
+    stock_coverage_days: Optional[float]
+
+
+@dataclass(frozen=True)
+class HerdProjection:
+    """Aggregates Module 3 outputs including nutrition and logistics."""
+
+    analysis: RationAnalysis
+    production_type: ProductionType
+    animal_count: int
+    herd_totals: Optional[RationTotals]
+    logistics: HerdLogisticsSummary
+    warnings: List[str]
+

--- a/app/models/nutrition.py
+++ b/app/models/nutrition.py
@@ -1,0 +1,62 @@
+"""Nutritional calculation result models for Module 2.
+
+This module defines lightweight data containers describing the output of the
+nutritional calculator. They are used both by the service layer and, later on,
+by the KivyMD user interface. Each model stores the computed value together
+with metadata explaining whether a value was estimated due to missing input
+data so that the UI can display the appropriate warnings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class NutrientMeasurement:
+    """Stores the numeric value of a nutrient along with estimation metadata."""
+
+    value: Optional[float]
+    is_estimated: bool = False
+
+    def normalized(self) -> Optional[float]:
+        """Return the stored value rounded to three decimals for presentation."""
+
+        if self.value is None:
+            return None
+        return round(self.value, 3)
+
+
+@dataclass(frozen=True)
+class FeedContribution:
+    """Represents a single feed's contribution to the ration totals."""
+
+    name: str
+    quantity_kg: float
+    dry_matter: NutrientMeasurement
+    protein: NutrientMeasurement
+    energy: NutrientMeasurement
+    fiber: NutrientMeasurement
+    dry_matter_share_percent: Optional[float]
+
+
+@dataclass(frozen=True)
+class RationTotals:
+    """Aggregated nutrient values for the whole ration or per animal."""
+
+    dry_matter: NutrientMeasurement
+    protein: NutrientMeasurement
+    energy: NutrientMeasurement
+    fiber: NutrientMeasurement
+
+
+@dataclass(frozen=True)
+class RationAnalysis:
+    """Stores the complete output of a ration calculation run."""
+
+    contributions: List[FeedContribution]
+    totals: RationTotals
+    per_animal: Optional[RationTotals]
+    warnings: List[str]
+

--- a/app/models/saved_ration.py
+++ b/app/models/saved_ration.py
@@ -1,0 +1,115 @@
+"""Models describing persisted rations and comparison outputs for Module 5."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Iterable, List
+
+from .feed import NutritionalProfile, RationFeedItem
+
+
+def _now_iso() -> str:
+    """Return the current UTC timestamp formatted for JSON serialization."""
+
+    return datetime.utcnow().isoformat(timespec="seconds")
+
+
+@dataclass(frozen=True)
+class SavedRation:
+    """Represents a ration stored on disk together with metadata."""
+
+    name: str
+    items: List[RationFeedItem]
+    created_at: str = field(default_factory=_now_iso)
+    updated_at: str = field(default_factory=_now_iso)
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialize the ration into a JSON friendly dictionary."""
+
+        return {
+            "name": self.name,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "items": [
+                {
+                    "name": item.name,
+                    "quantity_kg": item.quantity_kg,
+                    "use_default_profile": item.use_default_profile,
+                    "manual_profile": item.manual_profile.to_dict(),
+                }
+                for item in self.items
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "SavedRation":
+        """Recreate a :class:`SavedRation` from serialized data."""
+
+        items: List[RationFeedItem] = []
+        for raw in data.get("items", []):
+            profile_data = raw.get("manual_profile", {})  # type: ignore[arg-type]
+            profile = NutritionalProfile(
+                protein_percent=profile_data.get("protein_percent"),
+                energy_mj_per_kg_dm=profile_data.get("energy_mj_per_kg_dm"),
+                dry_matter_percent=profile_data.get("dry_matter_percent"),
+                fiber_percent=profile_data.get("fiber_percent"),
+            )
+            items.append(
+                RationFeedItem(
+                    name=raw.get("name", ""),  # type: ignore[arg-type]
+                    quantity_kg=float(raw.get("quantity_kg", 0.0)),
+                    use_default_profile=bool(raw.get("use_default_profile", True)),
+                    manual_profile=profile,
+                )
+            )
+        created = str(data.get("created_at", _now_iso()))
+        updated = str(data.get("updated_at", created))
+        return cls(
+            name=str(data.get("name", "")),
+            items=items,
+            created_at=created,
+            updated_at=updated,
+        )
+
+    def updated_copy(self, items: Iterable[RationFeedItem]) -> "SavedRation":
+        """Return a copy with replaced items and refreshed ``updated_at`` value."""
+
+        updated_iso = _now_iso()
+        return SavedRation(
+            name=self.name,
+            items=list(items),
+            created_at=self.created_at,
+            updated_at=updated_iso,
+        )
+
+
+@dataclass(frozen=True)
+class NutrientComparison:
+    """Stores formatted information for comparing two ration nutrients."""
+
+    label: str
+    first_label: str
+    second_label: str
+    difference_label: str
+
+
+@dataclass(frozen=True)
+class FeedShareComparison:
+    """Represents dry matter share comparison for a single feed."""
+
+    feed_name: str
+    first_label: str
+    second_label: str
+    difference_label: str
+
+
+@dataclass(frozen=True)
+class RationComparison:
+    """Aggregates nutrient and feed share comparisons for two rations."""
+
+    first_name: str
+    second_name: str
+    nutrient_cards: List[NutrientComparison] = field(default_factory=list)
+    feed_share_rows: List[FeedShareComparison] = field(default_factory=list)
+

--- a/app/models/validation.py
+++ b/app/models/validation.py
@@ -1,0 +1,68 @@
+"""Validation data structures supporting Module 6 input checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable, List, Set
+
+
+class ValidationSeverity(str, Enum):
+    """Enumeration describing how severe a validation issue is."""
+
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """Represents a single validation problem detected in user input."""
+
+    field: str
+    message: str
+    severity: ValidationSeverity = ValidationSeverity.WARNING
+
+
+@dataclass
+class ValidationReport:
+    """Aggregates validation issues and metadata about invalid inputs."""
+
+    issues: List[ValidationIssue] = field(default_factory=list)
+    invalid_items: Set[str] = field(default_factory=set)
+    invalid_fields: dict[str, Set[str]] = field(default_factory=dict)
+
+    def add_issue(
+        self,
+        field: str,
+        message: str,
+        severity: ValidationSeverity = ValidationSeverity.WARNING,
+    ) -> None:
+        """Append a new validation issue to the report."""
+
+        self.issues.append(ValidationIssue(field=field, message=message, severity=severity))
+
+    def extend(self, issues: Iterable[ValidationIssue]) -> None:
+        """Add pre-existing issues to the report."""
+
+        self.issues.extend(issues)
+
+    def mark_invalid_item(self, item_name: str) -> None:
+        """Remember that the provided ration item should be ignored by calculators."""
+
+        self.invalid_items.add(item_name)
+
+    def mark_invalid_field(self, item_name: str, field_key: str) -> None:
+        """Register a nutrient field that cannot be used in calculations."""
+
+        bucket = self.invalid_fields.setdefault(item_name, set())
+        bucket.add(field_key)
+
+    def messages(self) -> List[str]:
+        """Return validation issue messages for presentation to the user."""
+
+        return [issue.message for issue in self.issues]
+
+    def has_errors(self) -> bool:
+        """Return ``True`` when at least one blocking error was detected."""
+
+        return any(issue.severity == ValidationSeverity.ERROR for issue in self.issues)

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,16 @@
+"""Service layer utilities orchestrating data access and state management."""
+
+from .feed_repository import FeedRepository, RationManager
+from .herd_planner import HerdPlanner
+from .nutrition_calculator import RationCalculator
+from .saved_rations import SavedRationStore
+from .validation import RationValidator
+
+__all__ = [
+    "FeedRepository",
+    "RationManager",
+    "RationCalculator",
+    "HerdPlanner",
+    "SavedRationStore",
+    "RationValidator",
+]

--- a/app/services/feed_repository.py
+++ b/app/services/feed_repository.py
@@ -1,0 +1,213 @@
+"""Feed repository and ration management services for Module 1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Dict, Iterable, List, Optional
+
+from app.data.default_feeds import build_default_feeds
+from app.models.feed import FeedDefinition, FeedType, NutritionalProfile, RationFeedItem
+
+
+@dataclass
+class FeedRepository:
+    """Keeps track of catalog feeds (default dataset and user-specified entries)."""
+
+    _defaults: Dict[str, FeedDefinition] = field(default_factory=dict)
+    _custom: Dict[str, FeedDefinition] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self._defaults:
+            self._defaults = {feed.name: feed for feed in build_default_feeds()}
+
+    # -- catalog management -------------------------------------------------
+    def list_feeds(self, feed_type: Optional[FeedType] = None) -> List[FeedDefinition]:
+        """Return feeds filtered by type. Custom entries override defaults by name."""
+
+        merged = {**self._defaults, **self._custom}
+        items = list(merged.values())
+        if feed_type is None:
+            return sorted(items, key=lambda feed: feed.name)
+        return sorted(
+            [feed for feed in items if feed.feed_type == feed_type],
+            key=lambda feed: feed.name,
+        )
+
+    def get_feed(self, name: str) -> Optional[FeedDefinition]:
+        """Return the feed definition with the given name if present."""
+
+        return self._custom.get(name) or self._defaults.get(name)
+
+    def add_custom_feed(
+        self,
+        name: str,
+        feed_type: FeedType,
+        profile: NutritionalProfile,
+        source: Optional[str] = None,
+        added_on: Optional[date] = None,
+    ) -> FeedDefinition:
+        """Register a user-defined feed and return its definition.
+
+        Raises ``ValueError`` when the name already exists in either dataset. The method
+        returns the saved definition for further chaining.
+        """
+
+        if name in self._defaults or name in self._custom:
+            raise ValueError(f"Feed named '{name}' already exists")
+        definition = FeedDefinition(
+            name=name,
+            feed_type=feed_type,
+            profile=profile,
+            source=source,
+            added_on=added_on or date.today(),
+            is_default=False,
+        )
+        self._custom[name] = definition
+        return definition
+
+    def update_feed_profile(self, name: str, profile: NutritionalProfile) -> FeedDefinition:
+        """Replace the nutritional profile for an existing feed."""
+
+        if name in self._custom:
+            definition = self._custom[name].with_profile(profile)
+            self._custom[name] = definition
+            return definition
+        if name in self._defaults:
+            definition = self._defaults[name].with_profile(profile)
+            self._defaults[name] = definition
+            return definition
+        raise KeyError(f"Feed '{name}' not found")
+
+    def remove_feed(self, name: str) -> None:
+        """Delete a custom feed from the catalog. Defaults cannot be removed."""
+
+        if name in self._custom:
+            del self._custom[name]
+        elif name in self._defaults:
+            raise ValueError("Cannot remove default feed entry")
+        else:
+            raise KeyError(f"Feed '{name}' not found")
+
+    def reset_default_profile(self, name: str) -> FeedDefinition:
+        """Restore default nutritional values by discarding custom overrides."""
+
+        if name in self._custom:
+            return self._custom[name]
+        if name in self._defaults:
+            defaults = build_default_feeds()
+            lookup = {feed.name: feed for feed in defaults}
+            definition = lookup.get(name)
+            if definition is None:
+                raise KeyError(f"Default feed '{name}' missing from dataset")
+            self._defaults[name] = definition
+            return definition
+        raise KeyError(f"Feed '{name}' not found")
+
+    # -- ration management --------------------------------------------------
+    def create_ration_item(
+        self,
+        name: str,
+        quantity_kg: float,
+        use_default_profile: bool = True,
+        manual_profile: Optional[NutritionalProfile] = None,
+    ) -> RationFeedItem:
+        """Create a ration feed item with validation and sensible defaults."""
+
+        definition = self.get_feed(name)
+        if definition is None and use_default_profile:
+            raise KeyError(
+                "Cannot use default values because the feed is absent from the catalog",
+            )
+        profile = manual_profile or NutritionalProfile()
+        return RationFeedItem(
+            name=name,
+            quantity_kg=quantity_kg,
+            use_default_profile=use_default_profile,
+            manual_profile=profile,
+        )
+
+    def apply_default_profile(self, item: RationFeedItem) -> RationFeedItem:
+        """Return a copy of ``item`` whose manual profile merges catalog defaults."""
+
+        definition = self.get_feed(item.name)
+        if not definition:
+            return item
+        merged = item.manual_profile.merged_with(definition.profile)
+        return RationFeedItem(
+            name=item.name,
+            quantity_kg=item.quantity_kg,
+            use_default_profile=item.use_default_profile,
+            manual_profile=merged,
+        )
+
+
+@dataclass
+class RationManager:
+    """Handles collection-level operations on ration feed items."""
+
+    repository: FeedRepository
+    _items: Dict[str, RationFeedItem] = field(default_factory=dict)
+
+    def list_items(self) -> List[RationFeedItem]:
+        """Return all ration items sorted by name to ensure deterministic order."""
+
+        return [self._items[key] for key in sorted(self._items)]
+
+    def add_or_update_item(self, item: RationFeedItem) -> None:
+        """Insert or replace a ration item based on its name."""
+
+        self._items[item.name] = item
+
+    def remove_item(self, name: str) -> None:
+        """Remove a feed from the ration. Raises ``KeyError`` when missing."""
+
+        if name not in self._items:
+            raise KeyError(f"Feed '{name}' not part of the ration")
+        del self._items[name]
+
+    def replace_items(self, items: Iterable[RationFeedItem]) -> None:
+        """Replace the current ration with the provided collection of items."""
+
+        self._items = {item.name: item for item in items}
+
+    def toggle_default_usage(self, name: str, use_default: bool) -> RationFeedItem:
+        """Update the flag controlling whether catalog defaults should be applied."""
+
+        if name not in self._items:
+            raise KeyError(f"Feed '{name}' not part of the ration")
+        item = self._items[name]
+        updated = RationFeedItem(
+            name=item.name,
+            quantity_kg=item.quantity_kg,
+            use_default_profile=use_default,
+            manual_profile=item.manual_profile,
+        )
+        self._items[name] = updated
+        return updated
+
+    def resolve_profiles(self) -> Dict[str, NutritionalProfile]:
+        """Return nutritional profiles for each item according to current settings."""
+
+        catalog = self.repository.list_feeds()
+        return {
+            name: item.resolve_profile(catalog)
+            for name, item in self._items.items()
+        }
+
+    def replace_manual_with_default(self, name: str) -> RationFeedItem:
+        """Overwrite manual values with catalog defaults for a given ration item."""
+
+        if name not in self._items:
+            raise KeyError(f"Feed '{name}' not part of the ration")
+        definition = self.repository.get_feed(name)
+        if not definition:
+            raise KeyError("Default feed definition unavailable")
+        updated = RationFeedItem(
+            name=name,
+            quantity_kg=self._items[name].quantity_kg,
+            use_default_profile=True,
+            manual_profile=definition.profile,
+        )
+        self._items[name] = updated
+        return updated

--- a/app/services/herd_planner.py
+++ b/app/services/herd_planner.py
@@ -1,0 +1,171 @@
+"""Herd-level planning services for Module 3."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import ceil
+from typing import Iterable, List, Optional, Tuple
+
+from app.models.feed import RationFeedItem
+from app.models.herd import HerdLogisticsSummary, HerdProjection, ProductionType
+from app.models.nutrition import NutrientMeasurement, RationAnalysis, RationTotals
+from app.services.nutrition_calculator import RationCalculator
+
+
+@dataclass
+class HerdPlanner:
+    """Combine ration analytics with herd logistics calculations."""
+
+    calculator: RationCalculator
+
+    def plan(
+        self,
+        items: Iterable[RationFeedItem],
+        animal_count: int,
+        production_type: ProductionType,
+        mixer_capacity_kg: Optional[float] = None,
+        wagon_capacity_kg: Optional[float] = None,
+        stock_mass_kg: Optional[float] = None,
+    ) -> HerdProjection:
+        """Return an aggregated herd projection for the provided parameters."""
+
+        item_list = list(items)
+        analysis = self.calculator.calculate(item_list, animal_count=animal_count)
+        herd_totals, herd_warnings = self._scale_totals(analysis, animal_count)
+        logistics, logistic_warnings = self._build_logistics(
+            item_list,
+            animal_count,
+            mixer_capacity_kg,
+            wagon_capacity_kg,
+            stock_mass_kg,
+        )
+
+        warnings = list(analysis.warnings)
+        warnings.extend(herd_warnings)
+        warnings.extend(logistic_warnings)
+
+        return HerdProjection(
+            analysis=analysis,
+            production_type=production_type,
+            animal_count=animal_count,
+            herd_totals=herd_totals,
+            logistics=logistics,
+            warnings=warnings,
+        )
+
+    def _scale_totals(
+        self, analysis: RationAnalysis, animal_count: int
+    ) -> Tuple[Optional[RationTotals], List[str]]:
+        """Return ration totals scaled to the entire herd when possible."""
+
+        warnings: List[str] = []
+        if animal_count <= 0:
+            warnings.append(
+                "Nie można przeliczyć składników na całe stado przy niedodatniej liczbie zwierząt.",
+            )
+            return None, warnings
+
+        per_animal = analysis.per_animal
+        if per_animal is None:
+            warnings.append(
+                "Brak danych o składnikach na sztukę – pominięto przeliczenie dla stada.",
+            )
+            return None, warnings
+
+        return (
+            RationTotals(
+                dry_matter=self._multiply_measurement(per_animal.dry_matter, animal_count),
+                protein=self._multiply_measurement(per_animal.protein, animal_count),
+                energy=self._multiply_measurement(per_animal.energy, animal_count),
+                fiber=self._multiply_measurement(per_animal.fiber, animal_count),
+            ),
+            warnings,
+        )
+
+    def _multiply_measurement(
+        self, measurement: NutrientMeasurement, multiplier: int
+    ) -> NutrientMeasurement:
+        """Scale nutrient values while keeping estimation metadata intact."""
+
+        if measurement.value is None:
+            return NutrientMeasurement(value=None, is_estimated=True)
+        return NutrientMeasurement(
+            value=measurement.value * multiplier,
+            is_estimated=measurement.is_estimated,
+        )
+
+    def _build_logistics(
+        self,
+        items: Iterable[RationFeedItem],
+        animal_count: int,
+        mixer_capacity_kg: Optional[float],
+        wagon_capacity_kg: Optional[float],
+        stock_mass_kg: Optional[float],
+    ) -> Tuple[HerdLogisticsSummary, List[str]]:
+        """Calculate feed mass requirements and logistics indicators."""
+
+        warnings: List[str] = []
+        per_animal_fresh_mass = sum(item.quantity_kg for item in items)
+
+        if animal_count <= 0:
+            warnings.append(
+                "Liczba zwierząt musi być dodatnia, aby policzyć zapotrzebowanie stada.",
+            )
+            daily_total = None
+        else:
+            daily_total = per_animal_fresh_mass * animal_count
+
+        monthly_total = daily_total * 30 if daily_total is not None else None
+        mixer_loads = self._compute_loads(daily_total, mixer_capacity_kg, "mieszalnika", warnings)
+        wagon_loads = self._compute_loads(daily_total, wagon_capacity_kg, "paszowozu", warnings)
+        stock_days = self._compute_stock_coverage(daily_total, stock_mass_kg, warnings)
+
+        return (
+            HerdLogisticsSummary(
+                per_animal_fresh_mass_kg=per_animal_fresh_mass,
+                daily_fresh_mass_kg=daily_total,
+                monthly_fresh_mass_kg=monthly_total,
+                mixer_loads_per_day=mixer_loads,
+                wagon_loads_per_day=wagon_loads,
+                stock_coverage_days=stock_days,
+            ),
+            warnings,
+        )
+
+    def _compute_loads(
+        self,
+        daily_total: Optional[float],
+        capacity: Optional[float],
+        label: str,
+        warnings: List[str],
+    ) -> Optional[int]:
+        """Return number of loads needed per day for the specified capacity."""
+
+        if capacity is None:
+            return None
+        if capacity <= 0:
+            warnings.append(
+                f"Pojemność {label} musi być dodatnia, pominięto obliczenie liczby załadunków.",
+            )
+            return None
+        if daily_total is None:
+            return None
+        return int(ceil(daily_total / capacity))
+
+    def _compute_stock_coverage(
+        self,
+        daily_total: Optional[float],
+        stock_mass_kg: Optional[float],
+        warnings: List[str],
+    ) -> Optional[float]:
+        """Return number of days the provided stock will last."""
+
+        if stock_mass_kg is None:
+            return None
+        if stock_mass_kg <= 0:
+            warnings.append("Zapas paszy musi być dodatni, aby obliczyć wystarczalność.")
+            return None
+        if daily_total is None or daily_total == 0:
+            return None
+        return round(stock_mass_kg / daily_total, 2)
+

--- a/app/services/nutrition_calculator.py
+++ b/app/services/nutrition_calculator.py
@@ -1,0 +1,292 @@
+"""Nutritional calculation services for Module 2."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Set, Tuple
+
+from app.models.feed import NutritionalProfile, RationFeedItem
+from app.models.nutrition import (
+    FeedContribution,
+    NutrientMeasurement,
+    RationAnalysis,
+    RationTotals,
+)
+from app.services.feed_repository import FeedRepository
+from app.services.validation import RationValidator
+
+
+@dataclass
+class NutrientAccumulator:
+    """Helper accumulating nutrient values across feed contributions."""
+
+    value: float = 0.0
+    has_data: bool = False
+    estimated: bool = False
+
+    def add(self, measurement: NutrientMeasurement) -> None:
+        """Add the provided measurement to the accumulator."""
+
+        if measurement.value is None:
+            self.estimated = True
+            return
+        self.value += measurement.value
+        self.has_data = True
+        if measurement.is_estimated:
+            self.estimated = True
+
+    def to_measurement(self) -> NutrientMeasurement:
+        """Transform the accumulator into a :class:`NutrientMeasurement`."""
+
+        if not self.has_data:
+            return NutrientMeasurement(value=None, is_estimated=self.estimated)
+        return NutrientMeasurement(value=self.value, is_estimated=self.estimated)
+
+
+class RationCalculator:
+    """Perform nutrient calculations for the current ration."""
+
+    def __init__(
+        self,
+        repository: FeedRepository,
+        validator: Optional[RationValidator] = None,
+    ) -> None:
+        self._repository = repository
+        self._validator = validator or RationValidator()
+
+    def calculate(
+        self,
+        items: Iterable[RationFeedItem],
+        animal_count: int | None = None,
+    ) -> RationAnalysis:
+        """Calculate nutrient contributions and totals for provided ration items."""
+
+        item_list = list(items)
+        catalog = self._repository.list_feeds()
+
+        validation = self._validator.validate(item_list, catalog)
+        contributions: List[FeedContribution] = []
+        warnings: List[str] = list(validation.messages())
+
+        # Prepare accumulators for totals across all feeds.
+        dry_matter_acc = NutrientAccumulator()
+        protein_acc = NutrientAccumulator()
+        energy_acc = NutrientAccumulator()
+        fiber_acc = NutrientAccumulator()
+
+        # Compute per-item contributions.
+        for item in item_list:
+            profile = item.resolve_profile(catalog)
+            if item.name in validation.invalid_items:
+                contribution = self._empty_contribution(item)
+                contributions.append(contribution)
+                continue
+            invalid_fields = validation.invalid_fields.get(item.name, set())
+            contribution, contribution_warnings = self._calculate_contribution(
+                item, profile, invalid_fields
+            )
+            contributions.append(contribution)
+            warnings.extend(contribution_warnings)
+
+            dry_matter_acc.add(contribution.dry_matter)
+            protein_acc.add(contribution.protein)
+            energy_acc.add(contribution.energy)
+            fiber_acc.add(contribution.fiber)
+
+        totals = RationTotals(
+            dry_matter=dry_matter_acc.to_measurement(),
+            protein=protein_acc.to_measurement(),
+            energy=energy_acc.to_measurement(),
+            fiber=fiber_acc.to_measurement(),
+        )
+
+        self._append_estimation_warning("sucha masa", totals.dry_matter, warnings)
+        self._append_estimation_warning("białko", totals.protein, warnings)
+        self._append_estimation_warning("energia", totals.energy, warnings)
+        self._append_estimation_warning("włókno", totals.fiber, warnings)
+
+        per_animal = self._compute_per_animal_totals(totals, animal_count, warnings)
+        contributions = self._apply_dry_matter_shares(contributions, totals, warnings)
+
+        return RationAnalysis(
+            contributions=contributions,
+            totals=totals,
+            per_animal=per_animal,
+            warnings=warnings,
+        )
+
+    def _empty_contribution(self, item: RationFeedItem) -> FeedContribution:
+        """Return a contribution placeholder for invalid ration items."""
+
+        empty = NutrientMeasurement(value=None, is_estimated=True)
+        return FeedContribution(
+            name=item.name,
+            quantity_kg=item.quantity_kg,
+            dry_matter=empty,
+            protein=empty,
+            energy=empty,
+            fiber=empty,
+            dry_matter_share_percent=None,
+        )
+
+    def _calculate_contribution(
+        self,
+        item: RationFeedItem,
+        profile: NutritionalProfile,
+        invalid_fields: Set[str],
+    ) -> Tuple[FeedContribution, List[str]]:
+        """Compute nutrient contribution for a single ration item."""
+
+        warnings: List[str] = []
+
+        dry_matter = self._percentage_measurement(
+            item,
+            profile.dry_matter_percent,
+            "sucha masa",
+            warnings,
+            field_key="dry_matter_percent",
+            invalid_fields=invalid_fields,
+        )
+        protein = self._percentage_measurement(
+            item,
+            profile.protein_percent,
+            "białko",
+            warnings,
+            field_key="protein_percent",
+            invalid_fields=invalid_fields,
+        )
+
+        if "energy" in invalid_fields:
+            energy = NutrientMeasurement(value=None, is_estimated=True)
+        elif dry_matter.value is None or profile.energy_mj_per_kg_dm is None:
+            energy = NutrientMeasurement(value=None, is_estimated=True)
+            if profile.energy_mj_per_kg_dm is None:
+                warnings.append(
+                    f"Pasza '{item.name}': brak danych o energii – wynik szacowany."
+                )
+        else:
+            energy = NutrientMeasurement(
+                value=dry_matter.value * profile.energy_mj_per_kg_dm,
+                is_estimated=dry_matter.is_estimated,
+            )
+
+        fiber = self._percentage_measurement(
+            item,
+            profile.fiber_percent,
+            "włókno",
+            warnings,
+            field_key="fiber_percent",
+            invalid_fields=invalid_fields,
+        )
+
+        contribution = FeedContribution(
+            name=item.name,
+            quantity_kg=item.quantity_kg,
+            dry_matter=dry_matter,
+            protein=protein,
+            energy=energy,
+            fiber=fiber,
+            dry_matter_share_percent=None,
+        )
+        return contribution, warnings
+
+    def _percentage_measurement(
+        self,
+        item: RationFeedItem,
+        percent_value: float | None,
+        nutrient_label: str,
+        warnings: List[str],
+        *,
+        field_key: str,
+        invalid_fields: Set[str],
+    ) -> NutrientMeasurement:
+        """Return nutrient measurement for percentage based attributes."""
+
+        if field_key in invalid_fields:
+            return NutrientMeasurement(value=None, is_estimated=True)
+        if percent_value is None:
+            warnings.append(
+                f"Pasza '{item.name}': brak danych dla składnika '{nutrient_label}'."
+            )
+            return NutrientMeasurement(value=None, is_estimated=True)
+        value = item.quantity_kg * (percent_value / 100)
+        return NutrientMeasurement(value=value, is_estimated=False)
+
+    def _compute_per_animal_totals(
+        self,
+        totals: RationTotals,
+        animal_count: int | None,
+        warnings: List[str],
+    ) -> RationTotals | None:
+        """Derive per-animal nutrient totals if ``animal_count`` is valid."""
+
+        if animal_count is None:
+            return None
+        if animal_count <= 0:
+            warnings.append("Liczba zwierząt musi być dodatnia, pominięto przeliczenie na sztukę.")
+            return None
+
+        return RationTotals(
+            dry_matter=self._divide_measurement(totals.dry_matter, animal_count),
+            protein=self._divide_measurement(totals.protein, animal_count),
+            energy=self._divide_measurement(totals.energy, animal_count),
+            fiber=self._divide_measurement(totals.fiber, animal_count),
+        )
+
+    def _divide_measurement(
+        self, measurement: NutrientMeasurement, divisor: int
+    ) -> NutrientMeasurement:
+        """Divide nutrient values by ``divisor`` while keeping estimation metadata."""
+
+        if measurement.value is None:
+            return NutrientMeasurement(value=None, is_estimated=True)
+        return NutrientMeasurement(
+            value=measurement.value / divisor,
+            is_estimated=measurement.is_estimated,
+        )
+
+    def _apply_dry_matter_shares(
+        self,
+        contributions: List[FeedContribution],
+        totals: RationTotals,
+        warnings: List[str],
+    ) -> List[FeedContribution]:
+        """Populate the dry matter share for each contribution."""
+
+        total_dm = totals.dry_matter.value
+        if total_dm in (None, 0):
+            if totals.dry_matter.value is None:
+                warnings.append(
+                    "Nie można obliczyć udziałów suchej masy z powodu brakujących danych."
+                )
+            return contributions
+
+        updated: List[FeedContribution] = []
+        for contribution in contributions:
+            if contribution.dry_matter.value is None:
+                updated.append(contribution)
+                continue
+            share = (contribution.dry_matter.value / total_dm) * 100
+            updated.append(
+                FeedContribution(
+                    name=contribution.name,
+                    quantity_kg=contribution.quantity_kg,
+                    dry_matter=contribution.dry_matter,
+                    protein=contribution.protein,
+                    energy=contribution.energy,
+                    fiber=contribution.fiber,
+                    dry_matter_share_percent=round(share, 2),
+                )
+            )
+        return updated
+
+    def _append_estimation_warning(
+        self, label: str, measurement: NutrientMeasurement, warnings: List[str]
+    ) -> None:
+        """Add a warning when the provided measurement was estimated."""
+
+        if measurement.is_estimated:
+            warnings.append(
+                f"Suma składnika '{label}' została oszacowana z powodu braków w danych."
+            )
+

--- a/app/services/saved_rations.py
+++ b/app/services/saved_rations.py
@@ -1,0 +1,214 @@
+"""Persistence utilities for storing and comparing saved rations (Module 5)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from app.models.feed import RationFeedItem
+from app.models.nutrition import NutrientMeasurement, RationAnalysis
+from app.models.saved_ration import (
+    FeedShareComparison,
+    NutrientComparison,
+    RationComparison,
+    SavedRation,
+)
+
+
+def _default_storage_path() -> Path:
+    """Return the default JSON file used to persist saved rations."""
+
+    return Path(__file__).resolve().parents[1] / "data" / "saved_rations.json"
+
+
+@dataclass
+class SavedRationStore:
+    """Simple JSON-backed storage for named rations."""
+
+    path: Path = field(default_factory=_default_storage_path)
+
+    def _load_all(self) -> Dict[str, SavedRation]:
+        """Return all rations stored on disk indexed by name."""
+
+        if not self.path.exists():
+            return {}
+        with self.path.open("r", encoding="utf-8") as handle:
+            raw = json.load(handle)
+        rations = {}
+        for entry in raw:
+            ration = SavedRation.from_dict(entry)
+            if not ration.name:
+                continue
+            rations[ration.name] = ration
+        return rations
+
+    def _write_all(self, rations: Iterable[SavedRation]) -> None:
+        """Persist the provided collection of rations to disk."""
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = [ration.to_dict() for ration in rations]
+        with self.path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+
+    def list_rations(self) -> List[SavedRation]:
+        """Return saved rations ordered by last update descending."""
+
+        rations = list(self._load_all().values())
+        return sorted(rations, key=lambda item: item.updated_at, reverse=True)
+
+    def save(self, name: str, items: Iterable[RationFeedItem]) -> SavedRation:
+        """Create or update a ration entry with the provided items."""
+
+        rations = self._load_all()
+        existing = rations.get(name)
+        if existing is None:
+            ration = SavedRation(name=name, items=list(items))
+        else:
+            ration = existing.updated_copy(items)
+        rations[name] = ration
+        self._write_all(rations.values())
+        return ration
+
+    def load(self, name: str) -> SavedRation:
+        """Return the ration with ``name`` or raise ``KeyError`` if missing."""
+
+        rations = self._load_all()
+        try:
+            return rations[name]
+        except KeyError as exc:
+            raise KeyError(f"Saved ration '{name}' not found") from exc
+
+    def delete(self, name: str) -> None:
+        """Remove the ration entry from the persistent store."""
+
+        rations = self._load_all()
+        if name not in rations:
+            raise KeyError(f"Saved ration '{name}' not found")
+        del rations[name]
+        self._write_all(rations.values())
+
+
+def build_nutrient_comparison(
+    label: str,
+    first: NutrientMeasurement,
+    second: NutrientMeasurement,
+    unit: str,
+) -> NutrientComparison:
+    """Return a comparison card with formatted totals and differences."""
+
+    first_label = _format_measurement(first, unit)
+    second_label = _format_measurement(second, unit)
+    difference_label = _format_difference(first, second, unit)
+    return NutrientComparison(
+        label=label,
+        first_label=first_label,
+        second_label=second_label,
+        difference_label=difference_label,
+    )
+
+
+def _format_measurement(measurement: NutrientMeasurement, unit: str) -> str:
+    """Return a string representation for a nutrient measurement."""
+
+    if measurement.value is None:
+        return "brak danych"
+    suffix = f"{measurement.value:.2f} {unit}"
+    if measurement.is_estimated:
+        return f"{suffix} (szac.)"
+    return suffix
+
+
+def _format_difference(first: NutrientMeasurement, second: NutrientMeasurement, unit: str) -> str:
+    """Return the signed difference between two measurements."""
+
+    if first.value is None or second.value is None:
+        return "–"
+    delta = first.value - second.value
+    return f"{delta:+.2f} {unit}"
+
+
+def build_feed_share_rows(
+    first: RationAnalysis,
+    second: RationAnalysis,
+) -> List[FeedShareComparison]:
+    """Return dry matter share comparisons for feeds present in either ration."""
+
+    shares: Dict[str, Dict[str, Optional[float]]] = {}
+    for contribution in first.contributions:
+        shares.setdefault(contribution.name, {})["first"] = contribution.dry_matter_share_percent
+    for contribution in second.contributions:
+        shares.setdefault(contribution.name, {})["second"] = contribution.dry_matter_share_percent
+
+    rows: List[FeedShareComparison] = []
+    for name, values in sorted(shares.items()):
+        first_share = values.get("first")
+        second_share = values.get("second")
+        rows.append(
+            FeedShareComparison(
+                feed_name=name,
+                first_label=_format_optional_percent(first_share),
+                second_label=_format_optional_percent(second_share),
+                difference_label=_format_percent_difference(first_share, second_share),
+            )
+        )
+    return rows
+
+
+def _format_optional_percent(value: Optional[float]) -> str:
+    """Format optional percentage values with one decimal place."""
+
+    if value is None:
+        return "–"
+    return f"{value:.1f}%"
+
+
+def _format_percent_difference(
+    first: Optional[float],
+    second: Optional[float],
+) -> str:
+    """Format signed percent differences handling missing values."""
+
+    if first is None or second is None:
+        return "–"
+    delta = (first or 0.0) - (second or 0.0)
+    return f"{delta:+.1f}%"
+
+
+def build_comparison(
+    first_name: str,
+    first_analysis: RationAnalysis,
+    second_name: str,
+    second_analysis: RationAnalysis,
+) -> RationComparison:
+    """Construct a :class:`RationComparison` from two analyses."""
+
+    nutrient_cards = [
+        build_nutrient_comparison(
+            "Białko",
+            first_analysis.totals.protein,
+            second_analysis.totals.protein,
+            "kg",
+        ),
+        build_nutrient_comparison(
+            "Energia",
+            first_analysis.totals.energy,
+            second_analysis.totals.energy,
+            "MJ",
+        ),
+        build_nutrient_comparison(
+            "Sucha masa",
+            first_analysis.totals.dry_matter,
+            second_analysis.totals.dry_matter,
+            "kg",
+        ),
+    ]
+    feed_rows = build_feed_share_rows(first_analysis, second_analysis)
+    return RationComparison(
+        first_name=first_name,
+        second_name=second_name,
+        nutrient_cards=nutrient_cards,
+        feed_share_rows=feed_rows,
+    )
+

--- a/app/services/validation.py
+++ b/app/services/validation.py
@@ -1,0 +1,94 @@
+"""Validation helpers ensuring safe handling of incomplete or invalid inputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from app.models.feed import FeedDefinition, RationFeedItem
+from app.models.validation import ValidationReport, ValidationSeverity
+
+
+@dataclass
+class RationValidator:
+    """Validate ration items before nutritional calculations take place."""
+
+    def validate(
+        self,
+        items: Iterable[RationFeedItem],
+        catalog: Iterable[FeedDefinition],
+    ) -> ValidationReport:
+        """Return a report describing issues detected for ``items``.
+
+        The validator checks general ration rules (non-empty list, positive quantities)
+        and sanity ranges for nutritional values expressed as percentages or energy
+        densities. The catalog is needed so that items relying on default profiles can
+        be resolved prior to validation.
+        """
+
+        report = ValidationReport()
+        item_list = list(items)
+        if not item_list:
+            report.add_issue(
+                field="items",
+                message="Dawka nie zawiera żadnych pasz. Dodaj pozycje, aby uzyskać wynik.",
+            )
+            return report
+
+        catalog_list = list(catalog)
+        for item in item_list:
+            self._validate_quantity(item, report)
+            profile = item.resolve_profile(catalog_list)
+            self._validate_profile(item.name, profile.to_dict(), report)
+        return report
+
+    def _validate_quantity(self, item: RationFeedItem, report: ValidationReport) -> None:
+        """Ensure ration quantities are strictly positive."""
+
+        if item.quantity_kg <= 0:
+            report.add_issue(
+                field=f"item:{item.name}:quantity",
+                message=(
+                    f"Pasza '{item.name}': ilość musi być dodatnia. Pozycja została pominięta w obliczeniach."
+                ),
+                severity=ValidationSeverity.ERROR,
+            )
+            report.mark_invalid_item(item.name)
+
+    def _validate_profile(
+        self, feed_name: str, profile_dict: dict[str, float | None], report: ValidationReport
+    ) -> None:
+        """Validate nutrient ranges for the resolved profile values."""
+
+        percent_fields = [
+            ("dry_matter_percent", "sucha masa"),
+            ("protein_percent", "białko"),
+            ("fiber_percent", "włókno"),
+        ]
+        for field_key, label in percent_fields:
+            value = profile_dict.get(field_key)
+            if value is None:
+                continue
+            if value < 0 or value > 100:
+                report.add_issue(
+                    field=f"item:{feed_name}:{field_key}",
+                    message=(
+                        f"Pasza '{feed_name}': wartość '{label}' musi mieścić się w zakresie 0-100%. "
+                        "Pominięto ją w obliczeniach."
+                    ),
+                    severity=ValidationSeverity.ERROR,
+                )
+                report.mark_invalid_field(feed_name, field_key)
+
+        energy = profile_dict.get("energy_mj_per_kg_dm")
+        if energy is None:
+            return
+        if energy <= 0:
+            report.add_issue(
+                field=f"item:{feed_name}:energy",
+                message=(
+                    f"Pasza '{feed_name}': energia metab. musi być dodatnia. Pominięto ją w obliczeniach."
+                ),
+                severity=ValidationSeverity.ERROR,
+            )
+            report.mark_invalid_field(feed_name, "energy")

--- a/app/testing/__init__.py
+++ b/app/testing/__init__.py
@@ -1,0 +1,8 @@
+"""Utilities providing the final tester walkthrough for Module 7."""
+
+from .final_tester import FinalTester, WalkthroughReport
+
+__all__ = [
+    "FinalTester",
+    "WalkthroughReport",
+]

--- a/app/testing/final_tester.py
+++ b/app/testing/final_tester.py
@@ -1,0 +1,122 @@
+"""Final user walkthrough helpers that simulate an end-to-end application session."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from app.models.feed import NutritionalProfile, RationFeedItem
+from app.services import (
+    FeedRepository,
+    HerdPlanner,
+    RationCalculator,
+    RationManager,
+    SavedRationStore,
+)
+from app.ui import AppController, HerdPanelState, RationScreenState, SavedRationsState
+
+
+@dataclass(frozen=True)
+class WalkthroughReport:
+    """Collects UI states captured during the final tester walkthrough."""
+
+    reference_state: RationScreenState
+    manual_state: RationScreenState
+    final_state: RationScreenState
+    herd_state: HerdPanelState
+    saved_state: SavedRationsState
+
+
+class FinalTester:
+    """Drive a scripted scenario exercising all key modules of the application."""
+
+    def __init__(self, storage_path: Optional[Path] = None) -> None:
+        store = SavedRationStore(path=storage_path) if storage_path else SavedRationStore()
+        repository = FeedRepository()
+        ration_manager = RationManager(repository)
+        calculator = RationCalculator(repository)
+        planner = HerdPlanner(calculator)
+        self._controller = AppController.from_services(
+            repository,
+            ration_manager,
+            calculator,
+            planner,
+            store,
+        )
+
+    @property
+    def controller(self) -> AppController:
+        """Return the lazily prepared :class:`AppController` instance."""
+
+        return self._controller
+
+    def run_walkthrough(
+        self,
+        *,
+        animal_count: int = 30,
+        production_label: str = "mleczne",
+        mixer_capacity_kg: float = 500.0,
+        wagon_capacity_kg: float = 500.0,
+        stock_mass_kg: float = 25_000.0,
+    ) -> WalkthroughReport:
+        """Execute the scripted scenario and return the captured UI states."""
+
+        controller = self.controller
+        controller.prepare_sample_ration()
+        reference_state = controller.ration_controller.build_state(animal_count=animal_count)
+        controller.saved_controller.save_current("Dawka referencyjna")
+
+        manual_state = self._prepare_manual_variant(animal_count)
+        controller.saved_controller.save_current("Dawka ręczna testowa")
+
+        controller.saved_controller.load_into_manager("Dawka referencyjna")
+        final_state = controller.ration_controller.build_state(animal_count=animal_count)
+
+        herd_state = controller.herd_controller.build_state(
+            animal_count=animal_count,
+            production_label=production_label,
+            mixer_capacity_kg=mixer_capacity_kg,
+            wagon_capacity_kg=wagon_capacity_kg,
+            stock_mass_kg=stock_mass_kg,
+        )
+
+        saved_state = controller.saved_controller.build_state(
+            comparison_pair=("Dawka ręczna testowa", "Dawka referencyjna"),
+            animal_count=animal_count,
+        )
+
+        return WalkthroughReport(
+            reference_state=reference_state,
+            manual_state=manual_state,
+            final_state=final_state,
+            herd_state=herd_state,
+            saved_state=saved_state,
+        )
+
+    def _prepare_manual_variant(self, animal_count: int) -> RationScreenState:
+        """Adjust the sample ration to use manual data, returning updated UI state."""
+
+        controller = self.controller
+        manager = controller.ration_controller.ration_manager
+        repository = controller.ration_controller.repository
+        items = manager.list_items()
+        if not items:
+            raise ValueError("Brak pasz w dawce – przygotuj dawkę referencyjną wcześniej.")
+        base_item = items[0]
+        definition = repository.get_feed(base_item.name)
+        default_profile = definition.profile if definition else NutritionalProfile()
+        manual_profile = NutritionalProfile(
+            protein_percent=(default_profile.protein_percent or 0.0) + 1.0,
+            energy_mj_per_kg_dm=None,
+            dry_matter_percent=default_profile.dry_matter_percent,
+            fiber_percent=default_profile.fiber_percent,
+        )
+        updated_item = RationFeedItem(
+            name=base_item.name,
+            quantity_kg=base_item.quantity_kg + 1.0,
+            use_default_profile=False,
+            manual_profile=manual_profile,
+        )
+        manager.add_or_update_item(updated_item)
+        return controller.ration_controller.build_state(animal_count=animal_count)

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,0 +1,32 @@
+"""User interface helpers and KivyMD integration for Module 4."""
+
+from .controllers import AppController, HerdPanelController, RationScreenController, SavedRationsController
+from .state import (
+    FeedRowState,
+    HerdPanelState,
+    LogisticsCardState,
+    NutrientCardState,
+    RationScreenState,
+    SavedComparisonCardState,
+    SavedFeedShareRowState,
+    SavedRationRowState,
+    SavedRationsState,
+)
+from .app import NutritionPlannerApp
+
+__all__ = [
+    "AppController",
+    "HerdPanelController",
+    "RationScreenController",
+    "SavedRationsController",
+    "FeedRowState",
+    "HerdPanelState",
+    "LogisticsCardState",
+    "NutrientCardState",
+    "RationScreenState",
+    "SavedRationsState",
+    "SavedRationRowState",
+    "SavedComparisonCardState",
+    "SavedFeedShareRowState",
+    "NutritionPlannerApp",
+]

--- a/app/ui/app.py
+++ b/app/ui/app.py
@@ -1,0 +1,430 @@
+"""KivyMD application bootstrap wiring Module 4 UI with services."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from .controllers import AppController
+
+try:  # pragma: no cover - optional dependency
+    from kivy.metrics import dp
+    from kivymd.app import MDApp
+    from kivymd.uix.boxlayout import MDBoxLayout
+    from kivymd.uix.button import MDRaisedButton
+    from kivymd.uix.card import MDCard
+    from kivymd.uix.label import MDLabel
+    from kivymd.uix.list import MDList, OneLineListItem
+    from kivymd.uix.screen import MDScreen
+    from kivymd.uix.scrollview import MDScrollView
+    from kivymd.uix.tab import MDTabs, MDTabsBase
+    from kivymd.uix.textfield import MDTextField
+except ImportError:  # pragma: no cover - executed only when KivyMD absent
+    MDApp = None
+
+    class NutritionPlannerApp:  # type: ignore
+        """Fallback stub raised when KivyMD is not installed."""
+
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - defensive
+            raise ImportError(
+                "KivyMD nie jest zainstalowane. Zainstaluj pakiety 'kivy' oraz 'kivymd', aby uruchomić interfejs."
+            )
+else:
+
+    class _Tab(MDBoxLayout, MDTabsBase):
+        """Simple helper combining box layout with tab capabilities."""
+
+        def __init__(self, **kwargs) -> None:
+            super().__init__(orientation="vertical", padding=dp(16), spacing=dp(12), **kwargs)
+
+
+    class NutritionPlannerApp(MDApp):
+        """Concrete KivyMD application exposing the feeding planner screens."""
+
+        def __init__(
+            self,
+            controller: AppController,
+            default_animal_count: Optional[int] = None,
+            **kwargs,
+        ) -> None:
+            super().__init__(**kwargs)
+            self.controller = controller
+            self.controller.prepare_sample_ration()
+            self._current_animal_count: Optional[int] = default_animal_count
+            self._ration_feed_list: Optional[MDList] = None
+            self._ration_cards_box: Optional[MDBoxLayout] = None
+            self._ration_warning_box: Optional[MDBoxLayout] = None
+            self._herd_result_box: Optional[MDBoxLayout] = None
+            self._herd_warning_box: Optional[MDBoxLayout] = None
+            self._animal_field: Optional[MDTextField] = None
+            self._production_field: Optional[MDTextField] = None
+            self._mixer_field: Optional[MDTextField] = None
+            self._wagon_field: Optional[MDTextField] = None
+            self._stock_field: Optional[MDTextField] = None
+            self._saved_name_field: Optional[MDTextField] = None
+            self._saved_list: Optional[MDList] = None
+            self._saved_message_box: Optional[MDBoxLayout] = None
+            self._saved_comparison_box: Optional[MDBoxLayout] = None
+            self._saved_selected: List[str] = []
+
+        def build(self):  # pragma: no cover - UI runtime
+            self.title = "Planner dawek dla bydła"
+            self.theme_cls.primary_palette = "Green"
+            screen = MDScreen()
+            tabs = MDTabs()
+            screen.add_widget(tabs)
+
+            ration_tab = self._build_ration_tab()
+            ration_tab.text = "Dawka pokarmowa"
+            tabs.add_widget(ration_tab)
+
+            herd_tab = self._build_herd_tab()
+            herd_tab.text = "Panel hodowcy"
+            tabs.add_widget(herd_tab)
+
+            saved_tab = self._build_saved_tab()
+            saved_tab.text = "Zapisane dawki"
+            tabs.add_widget(saved_tab)
+
+            return screen
+
+        # -- ration tab -----------------------------------------------------
+        def _build_ration_tab(self) -> _Tab:
+            tab = _Tab()
+            scroll = MDScrollView()
+            feed_list = MDList()
+            scroll.add_widget(feed_list)
+            tab.add_widget(scroll)
+
+            cards_box = MDBoxLayout(orientation="vertical", spacing=dp(8))
+            tab.add_widget(cards_box)
+
+            warning_box = MDBoxLayout(orientation="vertical", spacing=dp(4))
+            tab.add_widget(warning_box)
+
+            self._ration_feed_list = feed_list
+            self._ration_cards_box = cards_box
+            self._ration_warning_box = warning_box
+            self._update_ration_state()
+            return tab
+
+        def _update_ration_state(self) -> None:
+            if self._ration_feed_list is None or self._ration_cards_box is None:
+                return
+            state = self.controller.ration_controller.build_state(
+                animal_count=self._current_animal_count
+            )
+
+            self._ration_feed_list.clear_widgets()
+            for row in state.feed_rows:
+                description = (
+                    f"{row.name} • {row.quantity_label} • SM {row.dry_matter_label} • "
+                    f"Białko {row.protein_label}"
+                )
+                if row.energy_label != "brak danych":
+                    description += f" • Energia {row.energy_label}"
+                item = OneLineListItem(text=description)
+                self._ration_feed_list.add_widget(item)
+
+            self._ration_cards_box.clear_widgets()
+            for card in state.summary_cards:
+                card_widget = MDCard(orientation="vertical", padding=dp(12), spacing=dp(4))
+                card_widget.add_widget(MDLabel(text=card.title, bold=True))
+                card_widget.add_widget(MDLabel(text=f"Suma: {card.total_label}"))
+                if card.per_animal_label:
+                    card_widget.add_widget(MDLabel(text=f"Na sztukę: {card.per_animal_label}"))
+                if card.estimated:
+                    card_widget.add_widget(MDLabel(text="* wartość szacowana", font_style="Caption"))
+                self._ration_cards_box.add_widget(card_widget)
+
+            if self._ration_warning_box is not None:
+                self._ration_warning_box.clear_widgets()
+                if state.warnings:
+                    for warning in state.warnings:
+                        self._ration_warning_box.add_widget(
+                            MDLabel(text=warning, theme_text_color="Error")
+                        )
+                else:
+                    self._ration_warning_box.add_widget(
+                        MDLabel(text="Brak ostrzeżeń", theme_text_color="Hint")
+                    )
+
+        # -- herd tab -------------------------------------------------------
+        def _build_herd_tab(self) -> _Tab:
+            tab = _Tab()
+
+            self._animal_field = MDTextField(
+                hint_text="Liczba zwierząt",
+                text=str(self._current_animal_count or 30),
+                helper_text="Podaj liczbę krów w stadzie",
+                helper_text_mode="on_focus",
+            )
+            tab.add_widget(self._animal_field)
+
+            self._production_field = MDTextField(
+                hint_text="Typ produkcji (mleczne/opasowe)",
+                text="mleczne",
+            )
+            tab.add_widget(self._production_field)
+
+            self._mixer_field = MDTextField(hint_text="Pojemność mieszalnika (kg)")
+            tab.add_widget(self._mixer_field)
+
+            self._wagon_field = MDTextField(hint_text="Pojemność paszowozu (kg)")
+            tab.add_widget(self._wagon_field)
+
+            self._stock_field = MDTextField(hint_text="Zapas paszy w magazynie (kg)")
+            tab.add_widget(self._stock_field)
+
+            recalc_button = MDRaisedButton(text="Przelicz")
+            recalc_button.bind(on_release=self._update_herd_results)
+            tab.add_widget(recalc_button)
+
+            result_box = MDBoxLayout(orientation="vertical", spacing=dp(8))
+            tab.add_widget(result_box)
+            self._herd_result_box = result_box
+
+            warning_box = MDBoxLayout(orientation="vertical", spacing=dp(4))
+            tab.add_widget(warning_box)
+            self._herd_warning_box = warning_box
+
+            self._update_herd_results()
+            return tab
+
+        def _update_herd_results(self, *_args) -> None:
+            if self._herd_result_box is None:
+                return
+            animal_count = self._parse_int_field(self._animal_field)
+            production_label = (self._production_field.text if self._production_field else "mleczne")
+            if animal_count is None:
+                self._display_herd_error("Podaj prawidłową liczbę zwierząt.")
+                return
+            try:
+                state = self.controller.herd_controller.build_state(
+                    animal_count=animal_count,
+                    production_label=production_label,
+                    mixer_capacity_kg=self._parse_float_field(self._mixer_field),
+                    wagon_capacity_kg=self._parse_float_field(self._wagon_field),
+                    stock_mass_kg=self._parse_float_field(self._stock_field),
+                )
+            except ValueError as exc:
+                self._display_herd_error(str(exc))
+                return
+
+            self._current_animal_count = animal_count
+            self._render_herd_state(state)
+            self._update_ration_state()
+
+        def _render_herd_state(self, state) -> None:
+            if self._herd_result_box is None or self._herd_warning_box is None:
+                return
+            self._herd_result_box.clear_widgets()
+            header = MDLabel(
+                text=(
+                    f"Typ produkcji: {state.production_type_label} | Zwierząt: {state.animal_count_label}"
+                ),
+                bold=True,
+            )
+            self._herd_result_box.add_widget(header)
+            self._herd_result_box.add_widget(
+                MDLabel(text=f"Dzienna porcja na sztukę: {state.per_animal_feed_label}")
+            )
+            for card in state.herd_nutrient_cards:
+                self._herd_result_box.add_widget(MDLabel(text=f"{card.title}: {card.total_label}"))
+            for card in state.logistics_cards:
+                self._herd_result_box.add_widget(MDLabel(text=f"{card.label}: {card.value_label}"))
+
+            self._herd_warning_box.clear_widgets()
+            if state.warnings:
+                for warning in state.warnings:
+                    self._herd_warning_box.add_widget(
+                        MDLabel(text=warning, theme_text_color="Error")
+                    )
+            else:
+                self._herd_warning_box.add_widget(
+                    MDLabel(text="Brak ostrzeżeń", theme_text_color="Hint")
+                )
+
+        def _display_herd_error(self, message: str) -> None:
+            if self._herd_warning_box is None:
+                return
+            self._herd_warning_box.clear_widgets()
+            self._herd_warning_box.add_widget(
+                MDLabel(text=message, theme_text_color="Error")
+            )
+
+        # -- saved tab ------------------------------------------------------
+        def _build_saved_tab(self) -> _Tab:
+            tab = _Tab()
+            self._saved_name_field = MDTextField(
+                hint_text="Nazwa dawki",
+                helper_text="Podaj nazwę przed zapisem",
+                helper_text_mode="on_focus",
+            )
+            tab.add_widget(self._saved_name_field)
+
+            button_row = MDBoxLayout(orientation="horizontal", spacing=dp(8), size_hint_y=None, height=dp(48))
+            save_button = MDRaisedButton(text="💾 Zapisz aktualną")
+            save_button.bind(on_release=self._on_save_current)
+            load_button = MDRaisedButton(text="📂 Wczytaj zaznaczoną")
+            load_button.bind(on_release=self._on_load_saved)
+            delete_button = MDRaisedButton(text="🗑 Usuń zaznaczoną")
+            delete_button.bind(on_release=self._on_delete_saved)
+            button_row.add_widget(save_button)
+            button_row.add_widget(load_button)
+            button_row.add_widget(delete_button)
+            tab.add_widget(button_row)
+
+            scroll = MDScrollView()
+            saved_list = MDList()
+            scroll.add_widget(saved_list)
+            tab.add_widget(scroll)
+            self._saved_list = saved_list
+
+            message_box = MDBoxLayout(orientation="vertical", spacing=dp(4))
+            tab.add_widget(message_box)
+            self._saved_message_box = message_box
+
+            comparison_box = MDBoxLayout(orientation="vertical", spacing=dp(8))
+            tab.add_widget(comparison_box)
+            self._saved_comparison_box = comparison_box
+
+            self._refresh_saved_state()
+            return tab
+
+        def _on_save_current(self, *_args) -> None:
+            name = self._saved_name_field.text.strip() if self._saved_name_field else ""
+            if not name:
+                self._display_saved_message("Podaj nazwę dawki przed zapisem.", error=True)
+                return
+            try:
+                self.controller.saved_controller.save_current(name)
+            except ValueError as exc:
+                self._display_saved_message(str(exc), error=True)
+                return
+            self._display_saved_message(f"Zapisano dawkę '{name}'.")
+            if self._saved_name_field:
+                self._saved_name_field.text = ""
+            self._refresh_saved_state()
+
+        def _on_load_saved(self, *_args) -> None:
+            if not self._saved_selected:
+                self._display_saved_message("Zaznacz dawkę na liście, aby ją wczytać.", error=True)
+                return
+            name = self._saved_selected[0]
+            try:
+                self.controller.saved_controller.load_into_manager(name)
+            except KeyError as exc:
+                self._display_saved_message(str(exc), error=True)
+                return
+            self._display_saved_message(f"Wczytano dawkę '{name}'.")
+            self._update_ration_state()
+
+        def _on_delete_saved(self, *_args) -> None:
+            if not self._saved_selected:
+                self._display_saved_message("Wybierz dawkę do usunięcia.", error=True)
+                return
+            name = self._saved_selected[0]
+            try:
+                self.controller.saved_controller.delete(name)
+            except KeyError as exc:
+                self._display_saved_message(str(exc), error=True)
+                return
+            self._display_saved_message(f"Usunięto dawkę '{name}'.")
+            self._saved_selected = [item for item in self._saved_selected if item != name]
+            self._refresh_saved_state()
+
+        def _toggle_saved_selection(self, name: str) -> None:
+            if name in self._saved_selected:
+                self._saved_selected = [item for item in self._saved_selected if item != name]
+            else:
+                if len(self._saved_selected) >= 2:
+                    self._saved_selected.pop(0)
+                self._saved_selected.append(name)
+            self._refresh_saved_state()
+
+        def _refresh_saved_state(self) -> None:
+            if self._saved_list is None or self._saved_message_box is None:
+                return
+            comparison_pair = None
+            if len(self._saved_selected) == 2:
+                comparison_pair = (self._saved_selected[0], self._saved_selected[1])
+            state = self.controller.saved_controller.build_state(
+                comparison_pair=comparison_pair,
+                animal_count=self._current_animal_count,
+            )
+
+            self._saved_list.clear_widgets()
+            for row in state.rows:
+                prefix = "✅ " if row.name in self._saved_selected else ""
+                item = OneLineListItem(text=f"{prefix}{row.name} — {row.subtitle}")
+                item.bind(on_release=lambda _widget, value=row.name: self._toggle_saved_selection(value))
+                self._saved_list.add_widget(item)
+
+            self._saved_message_box.clear_widgets()
+            if state.message:
+                self._saved_message_box.add_widget(
+                    MDLabel(text=state.message, theme_text_color="Hint")
+                )
+            else:
+                self._saved_message_box.add_widget(
+                    MDLabel(
+                        text="Zaznacz dwie dawki, aby zobaczyć porównanie składu.",
+                        theme_text_color="Hint",
+                    )
+                )
+
+            if self._saved_comparison_box is not None:
+                self._saved_comparison_box.clear_widgets()
+                if state.comparison_cards:
+                    cards_row = MDBoxLayout(orientation="horizontal", spacing=dp(8))
+                    for card in state.comparison_cards:
+                        widget = MDCard(orientation="vertical", padding=dp(12), spacing=dp(4))
+                        widget.add_widget(MDLabel(text=card.label, bold=True))
+                        widget.add_widget(MDLabel(text=card.first_label))
+                        widget.add_widget(MDLabel(text=card.second_label))
+                        widget.add_widget(MDLabel(text=f"Różnica: {card.difference_label}"))
+                        cards_row.add_widget(widget)
+                    self._saved_comparison_box.add_widget(cards_row)
+                if state.feed_share_rows:
+                    share_list = MDList()
+                    for row in state.feed_share_rows:
+                        description = (
+                            f"{row.feed_name}: {row.first_label} • {row.second_label} "
+                            f"({row.difference_label})"
+                        )
+                        share_list.add_widget(OneLineListItem(text=description))
+                    scroll = MDScrollView()
+                    scroll.add_widget(share_list)
+                    self._saved_comparison_box.add_widget(scroll)
+
+        def _display_saved_message(self, message: str, error: bool = False) -> None:
+            if self._saved_message_box is None:
+                return
+            self._saved_message_box.clear_widgets()
+            color = "Error" if error else "Hint"
+            self._saved_message_box.add_widget(
+                MDLabel(text=message, theme_text_color=color)
+            )
+
+        # -- helpers --------------------------------------------------------
+        def _parse_int_field(self, field: Optional[MDTextField]) -> Optional[int]:
+            if field is None:
+                return None
+            text = field.text.strip()
+            if not text:
+                return None
+            try:
+                return int(text)
+            except ValueError:
+                return None
+
+        def _parse_float_field(self, field: Optional[MDTextField]) -> Optional[float]:
+            if field is None:
+                return None
+            text = field.text.strip().replace(",", ".")
+            if not text:
+                return None
+            try:
+                return float(text)
+            except ValueError:
+                return None

--- a/app/ui/app.py
+++ b/app/ui/app.py
@@ -8,6 +8,7 @@ from .controllers import AppController
 
 try:  # pragma: no cover - optional dependency
     from kivy.metrics import dp
+    from kivy.properties import StringProperty
     from kivymd.app import MDApp
     from kivymd.uix.boxlayout import MDBoxLayout
     from kivymd.uix.button import MDRaisedButton
@@ -32,9 +33,21 @@ else:
 
     class _Tab(MDBoxLayout, MDTabsBase):
         """Simple helper combining box layout with tab capabilities."""
+        # KivyMD 1.2.0 oczekuje title albo icon; dodajemy obie właściwości.
+        title = StringProperty("")
+        icon = StringProperty("")
+        # Opcjonalnie utrzymujemy też 'text' dla wstecznej zgodności,
+        # gdyby gdzieś była użyta. Jeśli 'text' zostanie ustawione,
+        # przepisz je do 'title'.
+        text = StringProperty("")
 
         def __init__(self, **kwargs) -> None:
             super().__init__(orientation="vertical", padding=dp(16), spacing=dp(12), **kwargs)
+            # Synchronizacja: jeżeli ktoś ustawi text zamiast title, skopiuj do title.
+            if not self.title and self.text:
+                self.title = self.text
+            # Gdy text się zmieni w locie – aktualizuj title, o ile title nie jest jawnie ustawione.
+            self.bind(text=lambda *_: setattr(self, "title", self.text) if not self.title else None)
 
 
     class NutritionPlannerApp(MDApp):
@@ -74,15 +87,15 @@ else:
             screen.add_widget(tabs)
 
             ration_tab = self._build_ration_tab()
-            ration_tab.text = "Dawka pokarmowa"
+            ration_tab.title = "Dawka pokarmowa"
             tabs.add_widget(ration_tab)
 
             herd_tab = self._build_herd_tab()
-            herd_tab.text = "Panel hodowcy"
+            herd_tab.title = "Panel hodowcy"
             tabs.add_widget(herd_tab)
 
             saved_tab = self._build_saved_tab()
-            saved_tab.text = "Zapisane dawki"
+            saved_tab.title = "Zapisane dawki"
             tabs.add_widget(saved_tab)
 
             return screen

--- a/app/ui/controllers.py
+++ b/app/ui/controllers.py
@@ -1,0 +1,195 @@
+"""Controllers translating domain services into UI friendly state objects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from app.models.feed import FeedType
+from app.models.herd import ProductionType
+from app.models.saved_ration import RationComparison
+from app.services.feed_repository import FeedRepository, RationManager
+from app.services.herd_planner import HerdPlanner
+from app.services.nutrition_calculator import RationCalculator
+from app.services.saved_rations import SavedRationStore, build_comparison
+
+from .state import (
+    HerdPanelState,
+    RationScreenState,
+    SavedRationsState,
+    build_saved_rations_state,
+    describe_analysis,
+    describe_projection,
+)
+
+
+@dataclass
+class RationScreenController:
+    """Build the ration composition screen state using Module 1 and 2 services."""
+
+    repository: FeedRepository
+    ration_manager: RationManager
+    calculator: RationCalculator
+
+    def build_state(self, animal_count: Optional[int] = None) -> RationScreenState:
+        """Return a :class:`RationScreenState` describing the current ration."""
+
+        items = self.ration_manager.list_items()
+        analysis = self.calculator.calculate(items, animal_count=animal_count)
+        feed_type_lookup = {
+            definition.name: _format_feed_type(definition.feed_type)
+            for definition in self.repository.list_feeds()
+        }
+        uses_default_lookup = {
+            item.name: item.use_default_profile for item in items
+        }
+        return describe_analysis(analysis, feed_type_lookup, uses_default_lookup)
+
+
+@dataclass
+class HerdPanelController:
+    """Build the herd projection tab state using Module 3 services."""
+
+    planner: HerdPlanner
+    ration_manager: RationManager
+
+    def build_state(
+        self,
+        animal_count: int,
+        production_label: str,
+        mixer_capacity_kg: Optional[float] = None,
+        wagon_capacity_kg: Optional[float] = None,
+        stock_mass_kg: Optional[float] = None,
+    ) -> HerdPanelState:
+        """Return formatted herd projection results for UI presentation."""
+
+        try:
+            production_type = ProductionType.from_label(production_label)
+        except ValueError as exc:
+            raise ValueError(f"Nieznany typ produkcji: {production_label}") from exc
+        items = self.ration_manager.list_items()
+        projection = self.planner.plan(
+            items,
+            animal_count=animal_count,
+            production_type=production_type,
+            mixer_capacity_kg=mixer_capacity_kg,
+            wagon_capacity_kg=wagon_capacity_kg,
+            stock_mass_kg=stock_mass_kg,
+        )
+        return describe_projection(projection)
+
+
+@dataclass
+class SavedRationsController:
+    """Placeholder controller for Module 5 features."""
+
+    store: SavedRationStore
+    ration_manager: RationManager
+    calculator: RationCalculator
+
+    def build_state(
+        self,
+        comparison_pair: Optional[Tuple[str, str]] = None,
+        animal_count: Optional[int] = None,
+    ) -> SavedRationsState:
+        """Return list of saved rations and optional comparison summary."""
+
+        rations = self.store.list_rations()
+        comparison = None
+        if comparison_pair is not None:
+            comparison = self.compare_rations(
+                comparison_pair[0],
+                comparison_pair[1],
+                animal_count=animal_count,
+            )
+        return build_saved_rations_state(rations, comparison)
+
+    def save_current(self, name: str) -> None:
+        """Persist the ration currently held by the ration manager."""
+
+        items = self.ration_manager.list_items()
+        if not items:
+            raise ValueError("Aktualna dawka jest pusta – dodaj pasze przed zapisem.")
+        self.store.save(name, items)
+
+    def load_into_manager(self, name: str) -> None:
+        """Replace the current ration with a stored entry."""
+
+        ration = self.store.load(name)
+        self.ration_manager.replace_items(ration.items)
+
+    def delete(self, name: str) -> None:
+        """Remove a ration from the persistent store."""
+
+        self.store.delete(name)
+
+    def compare_rations(
+        self,
+        first: str,
+        second: str,
+        animal_count: Optional[int] = None,
+    ) -> RationComparison:
+        """Return comparison details for two saved ration entries."""
+
+        first_ration = self.store.load(first)
+        second_ration = self.store.load(second)
+        first_analysis = self.calculator.calculate(first_ration.items, animal_count=animal_count)
+        second_analysis = self.calculator.calculate(second_ration.items, animal_count=animal_count)
+        return build_comparison(first, first_analysis, second, second_analysis)
+
+
+@dataclass
+class AppController:
+    """High level façade wiring together screen controllers for the UI."""
+
+    ration_controller: RationScreenController
+    herd_controller: HerdPanelController
+    saved_controller: SavedRationsController
+
+    @classmethod
+    def from_services(
+        cls,
+        repository: FeedRepository,
+        ration_manager: RationManager,
+        calculator: RationCalculator,
+        planner: HerdPlanner,
+        store: Optional[SavedRationStore] = None,
+    ) -> "AppController":
+        """Convenience factory to instantiate the controller tree."""
+
+        ration = RationScreenController(repository, ration_manager, calculator)
+        herd = HerdPanelController(planner, ration_manager)
+        saved_store = store or SavedRationStore()
+        saved = SavedRationsController(saved_store, ration_manager, calculator)
+        return cls(ration_controller=ration, herd_controller=herd, saved_controller=saved)
+
+
+
+    def prepare_sample_ration(self) -> None:
+        """Populate the ration manager with the example diet if empty."""
+
+        if self.ration_controller.ration_manager.list_items():
+            return
+        repository = self.ration_controller.repository
+        manager = self.ration_controller.ration_manager
+        samples = [
+            ("Kiszonka z kukurydzy", 12.0),
+            ("Śruta sojowa", 4.0),
+            ("Wysłodki buraczane (susz)", 3.0),
+        ]
+        for name, quantity in samples:
+            try:
+                item = repository.create_ration_item(name=name, quantity_kg=quantity)
+            except KeyError:
+                # Skip feeds missing from the catalog.
+                continue
+            manager.add_or_update_item(item)
+
+def _format_feed_type(feed_type: FeedType) -> str:
+    """Return a Polish label for feed type values used in the UI."""
+
+    if feed_type == FeedType.ROUGHAGE:
+        return "Objętościowa"
+    if feed_type == FeedType.CONCENTRATE:
+        return "Treściwa"
+    return feed_type.value

--- a/app/ui/state.py
+++ b/app/ui/state.py
@@ -1,0 +1,334 @@
+"""View-model style data structures for presenting information in the UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional
+
+from app.models.herd import HerdProjection, ProductionType
+from app.models.nutrition import NutrientMeasurement, RationAnalysis
+from app.models.saved_ration import FeedShareComparison, RationComparison, SavedRation
+
+
+@dataclass(frozen=True)
+class FeedRowState:
+    """Represents a single row in the ration feed list."""
+
+    name: str
+    feed_type_label: str
+    quantity_label: str
+    dry_matter_label: str
+    protein_label: str
+    energy_label: str
+    fiber_label: str
+    uses_default_profile: bool
+
+
+@dataclass(frozen=True)
+class NutrientCardState:
+    """Describes a summary card showing nutrient totals."""
+
+    title: str
+    total_label: str
+    per_animal_label: Optional[str]
+    unit: str
+    estimated: bool
+    missing: bool = False
+
+
+@dataclass(frozen=True)
+class LogisticsCardState:
+    """Represents a single logistics metric in the herd panel."""
+
+    label: str
+    value_label: str
+
+
+@dataclass(frozen=True)
+class RationScreenState:
+    """Aggregates the ration feed rows, nutrient cards and warnings."""
+
+    feed_rows: List[FeedRowState] = field(default_factory=list)
+    summary_cards: List[NutrientCardState] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class HerdPanelState:
+    """Stores formatted herd projection results for the UI."""
+
+    production_type_label: str
+    animal_count_label: str
+    per_animal_feed_label: str
+    herd_nutrient_cards: List[NutrientCardState] = field(default_factory=list)
+    logistics_cards: List[LogisticsCardState] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SavedRationRowState:
+    """Represents a single saved ration entry with formatted metadata."""
+
+    name: str
+    subtitle: str
+
+
+@dataclass(frozen=True)
+class SavedComparisonCardState:
+    """Summarises a nutrient comparison between two rations."""
+
+    label: str
+    first_label: str
+    second_label: str
+    difference_label: str
+
+
+@dataclass(frozen=True)
+class SavedFeedShareRowState:
+    """Presents dry matter share differences for an individual feed."""
+
+    feed_name: str
+    first_label: str
+    second_label: str
+    difference_label: str
+
+
+@dataclass(frozen=True)
+class SavedRationsState:
+    """Aggregates saved ration listings and optional comparison details."""
+
+    rows: List[SavedRationRowState] = field(default_factory=list)
+    comparison_cards: List[SavedComparisonCardState] = field(default_factory=list)
+    feed_share_rows: List[SavedFeedShareRowState] = field(default_factory=list)
+    message: Optional[str] = None
+
+
+def build_feed_row_state(
+    name: str,
+    feed_type_label: str,
+    quantity_kg: float,
+    dry_matter: NutrientMeasurement,
+    protein: NutrientMeasurement,
+    energy: NutrientMeasurement,
+    fiber: NutrientMeasurement,
+    uses_default_profile: bool,
+) -> FeedRowState:
+    """Return a ``FeedRowState`` with nicely formatted numeric values."""
+
+    return FeedRowState(
+        name=name,
+        feed_type_label=feed_type_label,
+        quantity_label=f"{quantity_kg:.2f} kg",
+        dry_matter_label=_format_measurement(dry_matter, "kg"),
+        protein_label=_format_measurement(protein, "kg"),
+        energy_label=_format_measurement(energy, "MJ"),
+        fiber_label=_format_measurement(fiber, "kg"),
+        uses_default_profile=uses_default_profile,
+    )
+
+
+def build_nutrient_card_state(
+    title: str,
+    totals: NutrientMeasurement,
+    per_animal: Optional[NutrientMeasurement],
+    unit: str,
+) -> NutrientCardState:
+    """Create a ``NutrientCardState`` summarising totals and per-animal values."""
+
+    total_label = _format_measurement(totals, unit)
+    per_animal_label = None
+    per_animal_estimated = False
+    if per_animal is not None:
+        per_animal_label = _format_measurement(per_animal, unit)
+        per_animal_estimated = per_animal.is_estimated
+    return NutrientCardState(
+        title=title,
+        total_label=total_label,
+        per_animal_label=per_animal_label,
+        unit=unit,
+        estimated=bool(totals.is_estimated or per_animal_estimated),
+        missing=totals.value is None,
+    )
+
+
+def build_ration_screen_state(
+    analysis: RationAnalysis,
+    feed_rows: List[FeedRowState],
+) -> RationScreenState:
+    """Return a ``RationScreenState`` derived from a ration analysis."""
+
+    per_animal = analysis.per_animal
+    cards = [
+        build_nutrient_card_state("Białko", analysis.totals.protein, per_animal.protein if per_animal else None, "kg"),
+        build_nutrient_card_state("Energia", analysis.totals.energy, per_animal.energy if per_animal else None, "MJ"),
+        build_nutrient_card_state("Sucha masa", analysis.totals.dry_matter, per_animal.dry_matter if per_animal else None, "kg"),
+        build_nutrient_card_state("Włókno", analysis.totals.fiber, per_animal.fiber if per_animal else None, "kg"),
+    ]
+    return RationScreenState(feed_rows=feed_rows, summary_cards=cards, warnings=analysis.warnings)
+
+
+def build_herd_panel_state(projection: HerdProjection) -> HerdPanelState:
+    """Convert a ``HerdProjection`` into strings ready for display."""
+
+    prod_label = _format_production_type(projection.production_type)
+    herd_cards: List[NutrientCardState] = []
+    if projection.herd_totals is not None:
+        herd_cards = [
+            build_nutrient_card_state("Białko (stado)", projection.herd_totals.protein, None, "kg"),
+            build_nutrient_card_state("Energia (stado)", projection.herd_totals.energy, None, "MJ"),
+            build_nutrient_card_state("Sucha masa (stado)", projection.herd_totals.dry_matter, None, "kg"),
+            build_nutrient_card_state("Włókno (stado)", projection.herd_totals.fiber, None, "kg"),
+        ]
+
+    logistics = projection.logistics
+    logistics_cards = [
+        LogisticsCardState("Dzienne zużycie", _format_optional_number(logistics.daily_fresh_mass_kg, "kg")),
+        LogisticsCardState("Miesięczne zapotrzebowanie", _format_optional_number(logistics.monthly_fresh_mass_kg, "kg")),
+        LogisticsCardState("Załadunki mieszalnika", _format_optional_int(logistics.mixer_loads_per_day)),
+        LogisticsCardState("Załadunki paszowozu", _format_optional_int(logistics.wagon_loads_per_day)),
+        LogisticsCardState("Wystarczalność zapasu", _format_optional_number(logistics.stock_coverage_days, "dni")),
+    ]
+
+    return HerdPanelState(
+        production_type_label=prod_label,
+        animal_count_label=str(projection.animal_count),
+        per_animal_feed_label=_format_optional_number(
+            logistics.per_animal_fresh_mass_kg, "kg/szt"
+        ),
+        herd_nutrient_cards=herd_cards,
+        logistics_cards=logistics_cards,
+        warnings=projection.warnings,
+    )
+
+
+def build_saved_rations_state(
+    rations: List[SavedRation],
+    comparison: Optional[RationComparison] = None,
+) -> SavedRationsState:
+    """Construct a :class:`SavedRationsState` from saved rations and comparison."""
+
+    rows = [build_saved_ration_row_state(ration) for ration in rations]
+    message = None if rows else "Brak zapisanych dawek"
+    cards: List[SavedComparisonCardState] = []
+    shares: List[SavedFeedShareRowState] = []
+    if comparison is not None:
+        cards = [
+            SavedComparisonCardState(
+                label=card.label,
+                first_label=f"{comparison.first_name}: {card.first_label}",
+                second_label=f"{comparison.second_name}: {card.second_label}",
+                difference_label=card.difference_label,
+            )
+            for card in comparison.nutrient_cards
+        ]
+        shares = [
+            SavedFeedShareRowState(
+                feed_name=row.feed_name,
+                first_label=f"{comparison.first_name}: {row.first_label}",
+                second_label=f"{comparison.second_name}: {row.second_label}",
+                difference_label=row.difference_label,
+            )
+            for row in comparison.feed_share_rows
+        ]
+    return SavedRationsState(
+        rows=rows,
+        comparison_cards=cards,
+        feed_share_rows=shares,
+        message=message,
+    )
+
+
+def build_saved_ration_row_state(ration: SavedRation) -> SavedRationRowState:
+    """Return a list row state summarising the saved ration metadata."""
+
+    count = len(ration.items)
+    item_label = "pasza" if count == 1 else "pasze"
+    updated_label = _format_timestamp(ration.updated_at)
+    subtitle = f"{count} {item_label} • zaktualizowano {updated_label}"
+    return SavedRationRowState(name=ration.name, subtitle=subtitle)
+
+
+def _format_measurement(measurement: NutrientMeasurement, unit: str) -> str:
+    """Return a Polish human readable string for a nutrient measurement."""
+
+    if measurement.value is None:
+        return "brak danych"
+    value = f"{measurement.value:.2f} {unit}"
+    if measurement.is_estimated:
+        return f"{value} (szac.)"
+    return value
+
+
+def _format_timestamp(value: str) -> str:
+    """Return a user facing date representation from an ISO timestamp."""
+
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return value
+    return parsed.strftime("%Y-%m-%d %H:%M")
+
+
+def _format_optional_number(value: Optional[float], unit: str) -> str:
+    """Format optional floats with a unit, returning an en dash for missing data."""
+
+    if value is None:
+        return "–"
+    return f"{value:.2f} {unit}"
+
+
+def _format_optional_int(value: Optional[int]) -> str:
+    """Format optional integers, returning an en dash for missing values."""
+
+    if value is None:
+        return "–"
+    return str(value)
+
+
+def _format_production_type(prod: ProductionType) -> str:
+    """Return a Polish label for a ``ProductionType`` enum value."""
+
+    return "Mleczne" if prod == ProductionType.MILK else "Opasowe"
+
+
+def derive_feed_rows(
+    analysis: RationAnalysis,
+    feed_type_lookup: dict[str, str],
+    uses_default_lookup: dict[str, bool],
+) -> List[FeedRowState]:
+    """Build feed row states from ration analysis and helper lookups."""
+
+    rows: List[FeedRowState] = []
+    for contribution in analysis.contributions:
+        feed_type_label = feed_type_lookup.get(contribution.name, "–")
+        rows.append(
+            build_feed_row_state(
+                name=contribution.name,
+                feed_type_label=feed_type_label,
+                quantity_kg=contribution.quantity_kg,
+                dry_matter=contribution.dry_matter,
+                protein=contribution.protein,
+                energy=contribution.energy,
+                fiber=contribution.fiber,
+                uses_default_profile=uses_default_lookup.get(contribution.name, False),
+            )
+        )
+    return rows
+
+
+def describe_analysis(
+    analysis: RationAnalysis,
+    feed_type_lookup: dict[str, str],
+    uses_default_lookup: dict[str, bool],
+) -> RationScreenState:
+    """Convenience helper to build a ``RationScreenState`` from raw inputs."""
+
+    feed_rows = derive_feed_rows(analysis, feed_type_lookup, uses_default_lookup)
+    return build_ration_screen_state(analysis, feed_rows)
+
+
+def describe_projection(projection: HerdProjection) -> HerdPanelState:
+    """Wrapper around :func:`build_herd_panel_state` for readability."""
+
+    return build_herd_panel_state(projection)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,43 @@
+"""Executable entry point launching the KivyMD cattle ration planner."""
+
+from __future__ import annotations
+
+from app.services import (
+    FeedRepository,
+    HerdPlanner,
+    RationCalculator,
+    RationManager,
+    SavedRationStore,
+)
+from app.ui import AppController, NutritionPlannerApp
+
+
+def build_controller() -> AppController:
+    """Construct an :class:`AppController` wired with default services."""
+
+    repository = FeedRepository()
+    ration_manager = RationManager(repository)
+    calculator = RationCalculator(repository)
+    planner = HerdPlanner(calculator)
+    store = SavedRationStore()
+    controller = AppController.from_services(
+        repository,
+        ration_manager,
+        calculator,
+        planner,
+        store,
+    )
+    controller.prepare_sample_ration()
+    return controller
+
+
+def main() -> None:
+    """Launch the graphical application if KivyMD is available."""
+
+    controller = build_controller()
+    app = NutritionPlannerApp(controller, default_animal_count=30)
+    app.run()  # type: ignore[attr-defined]
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for locating the application package."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_feed_repository.py
+++ b/tests/test_feed_repository.py
@@ -1,0 +1,87 @@
+"""Unit tests for Module 1 data management services."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.feed import FeedType, NutritionalProfile
+from app.services.feed_repository import FeedRepository, RationManager
+
+
+@pytest.fixture()
+def repository() -> FeedRepository:
+    return FeedRepository()
+
+
+def test_defaults_loaded(repository: FeedRepository) -> None:
+    feeds = repository.list_feeds()
+    assert any(feed.name == "Kiszonka z kukurydzy" for feed in feeds)
+    assert all(feed.is_default for feed in feeds)
+
+
+def test_filter_by_type(repository: FeedRepository) -> None:
+    roughage = repository.list_feeds(FeedType.ROUGHAGE)
+    assert all(feed.feed_type == FeedType.ROUGHAGE for feed in roughage)
+
+
+def test_add_custom_feed(repository: FeedRepository) -> None:
+    profile = NutritionalProfile(protein_percent=12.0, dry_matter_percent=40.0)
+    created = repository.add_custom_feed(
+        name="Lucerna", feed_type=FeedType.ROUGHAGE, profile=profile
+    )
+    assert not created.is_default
+    assert repository.get_feed("Lucerna") == created
+
+
+def test_prevent_duplicate_name(repository: FeedRepository) -> None:
+    profile = NutritionalProfile(protein_percent=12.0)
+    repository.add_custom_feed("Lucerna", FeedType.ROUGHAGE, profile)
+    with pytest.raises(ValueError):
+        repository.add_custom_feed("Lucerna", FeedType.ROUGHAGE, profile)
+
+
+def test_update_default_profile(repository: FeedRepository) -> None:
+    new_profile = NutritionalProfile(protein_percent=9.5)
+    updated = repository.update_feed_profile("Kiszonka z kukurydzy", new_profile)
+    assert updated.profile.protein_percent == 9.5
+
+
+def test_remove_custom_feed(repository: FeedRepository) -> None:
+    profile = NutritionalProfile()
+    repository.add_custom_feed("Test", FeedType.CONCENTRATE, profile)
+    repository.remove_feed("Test")
+    assert repository.get_feed("Test") is None
+
+
+def test_cannot_remove_default(repository: FeedRepository) -> None:
+    with pytest.raises(ValueError):
+        repository.remove_feed("Kiszonka z kukurydzy")
+
+
+def test_ration_manager_add_and_resolve(repository: FeedRepository) -> None:
+    manager = RationManager(repository)
+    item = repository.create_ration_item("Kiszonka z kukurydzy", 12.0, True)
+    manager.add_or_update_item(item)
+    resolved = manager.resolve_profiles()
+    profile = resolved["Kiszonka z kukurydzy"]
+    assert profile.dry_matter_percent == pytest.approx(32.0)
+
+
+def test_replace_manual_with_default(repository: FeedRepository) -> None:
+    manager = RationManager(repository)
+    manual = NutritionalProfile(protein_percent=11.0)
+    item = repository.create_ration_item(
+        "Kiszonka z kukurydzy", 10.0, use_default_profile=False, manual_profile=manual
+    )
+    manager.add_or_update_item(item)
+    manager.replace_manual_with_default("Kiszonka z kukurydzy")
+    updated = manager.resolve_profiles()["Kiszonka z kukurydzy"]
+    assert updated.protein_percent == pytest.approx(8.0)
+
+
+def test_toggle_default_usage(repository: FeedRepository) -> None:
+    manager = RationManager(repository)
+    item = repository.create_ration_item("Ziarno kukurydzy", 5.0, True)
+    manager.add_or_update_item(item)
+    manager.toggle_default_usage("Ziarno kukurydzy", False)
+    assert not manager.list_items()[0].use_default_profile

--- a/tests/test_final_tester.py
+++ b/tests/test_final_tester.py
@@ -1,0 +1,42 @@
+"""End-to-end walkthrough tests covering the final tester module (Module 7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.testing import FinalTester
+
+
+def test_final_tester_walkthrough_exercises_core_flows(tmp_path: Path) -> None:
+    """Running the scripted walkthrough should produce consistent UI states."""
+
+    tester = FinalTester(storage_path=tmp_path / "saved.json")
+    report = tester.run_walkthrough()
+
+    # Reference ration should match the preloaded sample with no warnings.
+    assert len(report.reference_state.feed_rows) == 3
+    assert report.reference_state.feed_rows[0].quantity_label == "12.00 kg"
+    assert report.reference_state.warnings == []
+
+    # Manual variant should mark energy as missing and trigger a warning.
+    manual_first = report.manual_state.feed_rows[0]
+    assert manual_first.quantity_label == "13.00 kg"
+    assert manual_first.energy_label == "brak danych"
+    assert any("brak danych o energii" in warning.lower() for warning in report.manual_state.warnings)
+
+    # After reloading the reference ration the state should match the original values.
+    final_first = report.final_state.feed_rows[0]
+    assert final_first.quantity_label == "12.00 kg"
+    assert report.final_state.warnings == []
+
+    # Herd panel state should expose expected logistics derived from the sample ration.
+    logistics = {card.label: card.value_label for card in report.herd_state.logistics_cards}
+    assert logistics["Dzienne zużycie"] == "570.00 kg"
+    assert logistics["Załadunki mieszalnika"] == "2"
+    assert logistics["Załadunki paszowozu"] == "2"
+
+    # Saved ration overview should list both entries and provide comparison details.
+    saved_names = {row.name for row in report.saved_state.rows}
+    assert {"Dawka referencyjna", "Dawka ręczna testowa"}.issubset(saved_names)
+    assert report.saved_state.comparison_cards, "Comparison cards should be populated"
+    assert report.saved_state.feed_share_rows, "Feed share differences should be available"

--- a/tests/test_herd_planner.py
+++ b/tests/test_herd_planner.py
@@ -1,0 +1,92 @@
+"""Tests covering Module 3 herd planning computations."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.herd import ProductionType
+from app.services.feed_repository import FeedRepository
+from app.services.herd_planner import HerdPlanner
+from app.services.nutrition_calculator import RationCalculator
+
+
+@pytest.fixture()
+def repository() -> FeedRepository:
+    """Return a feed repository populated with default data."""
+
+    return FeedRepository()
+
+
+@pytest.fixture()
+def planner(repository: FeedRepository) -> HerdPlanner:
+    """Return a planner composed of the repository and ration calculator."""
+
+    calculator = RationCalculator(repository)
+    return HerdPlanner(calculator)
+
+
+def _reference_items(repository: FeedRepository):
+    """Return ration items matching the specification reference ration."""
+
+    return [
+        repository.create_ration_item("Kiszonka z kukurydzy", quantity_kg=12.0),
+        repository.create_ration_item("Śruta sojowa", quantity_kg=4.0),
+        repository.create_ration_item("Wysłodki buraczane (susz)", quantity_kg=3.0),
+    ]
+
+
+def test_plan_returns_combined_projection(
+    planner: HerdPlanner, repository: FeedRepository
+) -> None:
+    """Ensure herd planner composes nutritional and logistics outputs."""
+
+    projection = planner.plan(
+        _reference_items(repository),
+        animal_count=30,
+        production_type=ProductionType.MILK,
+        mixer_capacity_kg=500.0,
+        wagon_capacity_kg=600.0,
+        stock_mass_kg=25_000.0,
+    )
+
+    assert projection.analysis.totals.dry_matter.value == pytest.approx(10.06, rel=1e-3)
+    assert projection.analysis.per_animal is not None
+
+    logistics = projection.logistics
+    assert logistics.per_animal_fresh_mass_kg == pytest.approx(19.0)
+    assert logistics.daily_fresh_mass_kg == pytest.approx(570.0)
+    assert logistics.monthly_fresh_mass_kg == pytest.approx(17_100.0)
+    assert logistics.mixer_loads_per_day == 2
+    assert logistics.wagon_loads_per_day == 1
+    assert logistics.stock_coverage_days == pytest.approx(43.86, rel=1e-3)
+
+    herd_totals = projection.herd_totals
+    assert herd_totals is not None
+    assert herd_totals.dry_matter.value == pytest.approx(
+        projection.analysis.per_animal.dry_matter.value * projection.animal_count,
+        rel=1e-3,
+    )
+    assert projection.warnings == []
+
+
+def test_plan_handles_invalid_parameters(
+    planner: HerdPlanner, repository: FeedRepository
+) -> None:
+    """Invalid numeric inputs should produce warnings and omit calculations."""
+
+    projection = planner.plan(
+        _reference_items(repository),
+        animal_count=0,
+        production_type=ProductionType.BEEF,
+        mixer_capacity_kg=-100.0,
+        wagon_capacity_kg=None,
+        stock_mass_kg=-500.0,
+    )
+
+    assert projection.herd_totals is None
+    assert projection.logistics.daily_fresh_mass_kg is None
+    assert projection.logistics.mixer_loads_per_day is None
+    assert projection.logistics.stock_coverage_days is None
+    assert any("Liczba zwierząt" in warning for warning in projection.warnings)
+    assert any("Pojemność" in warning for warning in projection.warnings)
+    assert any("Zapas paszy" in warning for warning in projection.warnings)

--- a/tests/test_nutrition_calculator.py
+++ b/tests/test_nutrition_calculator.py
@@ -1,0 +1,151 @@
+"""Tests covering Module 2 nutritional calculations."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.feed import NutritionalProfile
+from app.services.feed_repository import FeedRepository
+from app.services.nutrition_calculator import RationCalculator
+
+
+@pytest.fixture()
+def repository() -> FeedRepository:
+    """Return a feed repository populated with default data."""
+
+    return FeedRepository()
+
+
+@pytest.fixture()
+def calculator(repository: FeedRepository) -> RationCalculator:
+    """Return a calculator instance backed by the default feed repository."""
+
+    return RationCalculator(repository)
+
+
+def test_calculate_ration_totals_with_defaults(
+    calculator: RationCalculator, repository: FeedRepository
+) -> None:
+    """Verify totals using the reference ration described in the specification."""
+
+    items = [
+        repository.create_ration_item("Kiszonka z kukurydzy", quantity_kg=12.0),
+        repository.create_ration_item("Śruta sojowa", quantity_kg=4.0),
+        repository.create_ration_item("Wysłodki buraczane (susz)", quantity_kg=3.0),
+    ]
+
+    result = calculator.calculate(items, animal_count=30)
+
+    assert pytest.approx(result.totals.dry_matter.value, rel=1e-4) == 10.06
+    assert not result.totals.dry_matter.is_estimated
+    assert pytest.approx(result.totals.protein.value, rel=1e-4) == 3.03
+    assert pytest.approx(result.totals.energy.value, rel=1e-4) == 69.99
+    assert pytest.approx(result.totals.fiber.value, rel=1e-4) == 3.0
+
+    assert result.per_animal is not None
+    assert pytest.approx(result.per_animal.dry_matter.value, rel=1e-4) == 0.3353333
+    assert pytest.approx(result.per_animal.energy.value, rel=1e-4) == 2.333
+
+    shares = {item.name: item.dry_matter_share_percent for item in result.contributions}
+    assert shares == {
+        "Kiszonka z kukurydzy": pytest.approx(38.19, rel=1e-3),
+        "Śruta sojowa": pytest.approx(34.97, rel=1e-3),
+        "Wysłodki buraczane (susz)": pytest.approx(26.85, rel=1e-3),
+    }
+
+    assert result.warnings == []
+
+
+def test_calculate_handles_missing_data(
+    calculator: RationCalculator, repository: FeedRepository
+) -> None:
+    """Missing nutritional fields should trigger warnings and estimated totals."""
+
+    manual_profile = NutritionalProfile(fiber_percent=10.0)
+    item = repository.create_ration_item(
+        "Test pasza",
+        quantity_kg=5.0,
+        use_default_profile=False,
+        manual_profile=manual_profile,
+    )
+
+    result = calculator.calculate([item])
+
+    assert result.totals.dry_matter.value is None
+    assert result.totals.dry_matter.is_estimated
+    assert result.totals.energy.value is None
+    assert result.totals.energy.is_estimated
+    assert result.contributions[0].fiber.value == pytest.approx(0.5)
+
+    assert any("brak danych" in warning for warning in result.warnings)
+    assert any("Nie można obliczyć udziałów suchej masy" in warning for warning in result.warnings)
+
+
+def test_calculate_warns_on_empty_ration(calculator: RationCalculator) -> None:
+    """Empty ration lists should surface a helpful warning instead of crashing."""
+
+    result = calculator.calculate([])
+
+    assert result.contributions == []
+    assert any("Dawka nie zawiera żadnych pasz" in warning for warning in result.warnings)
+
+
+def test_calculate_skips_invalid_quantities(
+    calculator: RationCalculator, repository: FeedRepository
+) -> None:
+    """Non-positive quantities should be ignored with a dedicated validation message."""
+
+    invalid_item = repository.create_ration_item(
+        "Kiszonka z kukurydzy",
+        quantity_kg=0.0,
+        use_default_profile=True,
+    )
+
+    result = calculator.calculate([invalid_item])
+
+    assert result.contributions[0].dry_matter.value is None
+    assert any("ilość musi być dodatnia" in warning for warning in result.warnings)
+
+
+def test_calculate_marks_out_of_range_percentages(
+    calculator: RationCalculator, repository: FeedRepository
+) -> None:
+    """Percentages outside the 0-100 range should be ignored with warnings."""
+
+    manual_profile = NutritionalProfile(protein_percent=150.0, dry_matter_percent=-5.0)
+    item = repository.create_ration_item(
+        "Eksperymentalna",
+        quantity_kg=5.0,
+        use_default_profile=False,
+        manual_profile=manual_profile,
+    )
+
+    result = calculator.calculate([item])
+
+    contribution = result.contributions[0]
+    assert contribution.protein.value is None
+    assert contribution.dry_matter.value is None
+    assert any("zakresie 0-100" in warning for warning in result.warnings)
+
+
+def test_calculate_marks_invalid_energy(
+    calculator: RationCalculator, repository: FeedRepository
+) -> None:
+    """Negative energy values should be removed from calculations."""
+
+    manual_profile = NutritionalProfile(
+        protein_percent=12.0,
+        dry_matter_percent=30.0,
+        energy_mj_per_kg_dm=-1.0,
+    )
+    item = repository.create_ration_item(
+        "Energia błędna",
+        quantity_kg=4.0,
+        use_default_profile=False,
+        manual_profile=manual_profile,
+    )
+
+    result = calculator.calculate([item])
+
+    assert result.contributions[0].energy.value is None
+    assert any("energia metab." in warning for warning in result.warnings)

--- a/tests/test_saved_rations.py
+++ b/tests/test_saved_rations.py
@@ -1,0 +1,49 @@
+"""Tests for the saved rations persistence service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.models.feed import RationFeedItem
+from app.services import FeedRepository
+from app.services.saved_rations import SavedRationStore
+
+
+def build_item(repository: FeedRepository) -> RationFeedItem:
+    """Return a sample ration item from the default dataset."""
+
+    return repository.create_ration_item(name="Kiszonka z kukurydzy", quantity_kg=12.0)
+
+
+def test_saved_ration_store_roundtrip(tmp_path: Path) -> None:
+    """Saved rations should persist to disk and load back correctly."""
+
+    repository = FeedRepository()
+    store = SavedRationStore(path=tmp_path / "saved.json")
+    item = build_item(repository)
+
+    saved = store.save("Referencyjna", [item])
+    assert saved.name == "Referencyjna"
+
+    loaded = store.load("Referencyjna")
+    assert loaded.items[0].name == "Kiszonka z kukurydzy"
+
+    listed = store.list_rations()
+    assert [ration.name for ration in listed] == ["Referencyjna"]
+
+
+def test_saved_ration_store_delete(tmp_path: Path) -> None:
+    """Deleting a ration should remove it from persistent storage."""
+
+    repository = FeedRepository()
+    store = SavedRationStore(path=tmp_path / "saved.json")
+    item = build_item(repository)
+    store.save("Do usunięcia", [item])
+
+    store.delete("Do usunięcia")
+    assert store.list_rations() == []
+
+    with pytest.raises(KeyError):
+        store.delete("Nie istnieje")

--- a/tests/test_ui_controllers.py
+++ b/tests/test_ui_controllers.py
@@ -1,0 +1,127 @@
+"""Tests verifying the Module 4 UI controllers and state formatting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.services import (
+    FeedRepository,
+    HerdPlanner,
+    RationCalculator,
+    RationManager,
+    SavedRationStore,
+)
+from app.ui import AppController
+
+
+@pytest.fixture
+def controller(tmp_path: Path) -> AppController:
+    """Return an ``AppController`` populated with the reference ration."""
+
+    repository = FeedRepository()
+    ration_manager = RationManager(repository)
+    calculator = RationCalculator(repository)
+    planner = HerdPlanner(calculator)
+    store = SavedRationStore(path=tmp_path / "saved.json")
+    controller = AppController.from_services(
+        repository,
+        ration_manager,
+        calculator,
+        planner,
+        store,
+    )
+    controller.prepare_sample_ration()
+    return controller
+
+
+def test_ration_screen_state_uses_expected_formatting(controller: AppController) -> None:
+    """Ration screen state should expose formatted values for the sample ration."""
+
+    state = controller.ration_controller.build_state(animal_count=30)
+
+    assert len(state.feed_rows) == 3
+    first = state.feed_rows[0]
+    assert first.name == "Kiszonka z kukurydzy"
+    assert first.quantity_label == "12.00 kg"
+    assert first.dry_matter_label == "3.84 kg"
+    assert first.protein_label == "0.96 kg"
+
+    cards = {card.title: card for card in state.summary_cards}
+    assert cards["Białko"].total_label == "3.03 kg"
+    assert cards["Białko"].per_animal_label == "0.10 kg"
+    assert cards["Energia"].total_label == "69.99 MJ"
+    assert cards["Sucha masa"].total_label == "10.06 kg"
+    assert state.warnings == []
+
+
+def test_herd_panel_state_displays_logistics(controller: AppController) -> None:
+    """Herd panel should expose logistics values and derived warnings."""
+
+    state = controller.herd_controller.build_state(
+        animal_count=30,
+        production_label="mleczne",
+        mixer_capacity_kg=500,
+        wagon_capacity_kg=500,
+        stock_mass_kg=25000,
+    )
+
+    assert state.production_type_label == "Mleczne"
+    assert state.animal_count_label == "30"
+    assert state.per_animal_feed_label == "19.00 kg/szt"
+
+    logistics = {card.label: card.value_label for card in state.logistics_cards}
+    assert logistics["Dzienne zużycie"] == "570.00 kg"
+    assert logistics["Miesięczne zapotrzebowanie"] == "17100.00 kg"
+    assert logistics["Załadunki mieszalnika"] == "2"
+    assert logistics["Wystarczalność zapasu"] == "43.86 dni"
+    assert state.warnings == []
+
+
+def test_prepare_sample_ration_populates_manager(tmp_path: Path) -> None:
+    """Calling ``prepare_sample_ration`` should preload the reference diet."""
+
+    repository = FeedRepository()
+    ration_manager = RationManager(repository)
+    calculator = RationCalculator(repository)
+    planner = HerdPlanner(calculator)
+    store = SavedRationStore(path=tmp_path / "store.json")
+    controller = AppController.from_services(
+        repository,
+        ration_manager,
+        calculator,
+        planner,
+        store,
+    )
+
+    assert controller.ration_controller.ration_manager.list_items() == []
+    controller.prepare_sample_ration()
+    assert len(controller.ration_controller.ration_manager.list_items()) == 3
+
+
+def test_saved_rations_controller_persists_and_compares(controller: AppController) -> None:
+    """The saved rations controller should persist entries and provide comparisons."""
+
+    controller.saved_controller.save_current("Referencyjna")
+    # Modify ration and save a variant for comparison.
+    manager = controller.ration_controller.ration_manager
+    item = manager.list_items()[0]
+    manager.add_or_update_item(
+        type(item)(
+            name=item.name,
+            quantity_kg=item.quantity_kg + 1.0,
+            use_default_profile=item.use_default_profile,
+            manual_profile=item.manual_profile,
+        )
+    )
+    controller.saved_controller.save_current("Podbity udział")
+
+    state = controller.saved_controller.build_state(
+        comparison_pair=("Podbity udział", "Referencyjna"),
+        animal_count=30,
+    )
+
+    assert any(row.name == "Referencyjna" for row in state.rows)
+    assert any(card.label == "Sucha masa" for card in state.comparison_cards)
+    assert state.feed_share_rows, "Comparison should list feed share differences"


### PR DESCRIPTION
## Summary
- introduce the Module 7 final tester utilities that orchestrate an end-to-end walkthrough of the application
- add an integration-style pytest that validates the scripted tester scenario and ensures warnings/logistics are produced
- expand the README with module overview, installation, testing instructions and notes on packaging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68caef8aca588332a02053fac3b59cbb